### PR TITLE
Issue #233 - Check source existence before moving files

### DIFF
--- a/src/Core/ServiceWrapper/Main.cs
+++ b/src/Core/ServiceWrapper/Main.cs
@@ -124,6 +124,13 @@ namespace winsw
         {
             try
             {
+                if (!File.Exists(sourceFileName))
+                {
+                    throw new IOException("Source file does not exist");
+                }
+
+                //TODO: This logic is still not atomic, temp directory is required for
+                // File.Replace(sourceFileName, destFileName, TODO);
                 File.Delete(destFileName);
                 File.Move(sourceFileName, destFileName);
             }


### PR DESCRIPTION
Addresses #233 

- [x] - Check the source existence before copying
- [ ] - Use `File.Replace` to make operation atomic and to keep backups

CC @vladotod, you can use the current state of the PR as a temporary fix