### PR TITLE
Add stopwait command - same as stop, but waits until the service is actually stopped:

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Your renamed *WinSW.exe* binary also accepts the following commands:
 * `uninstall` to uninstall the service. The opposite operation of above.
 * `start` to start the service. The service must have already been installed.
 * `stop` to stop the service.
+* `stopwait` to stop the service and wait until it's actually stopped.
 * `restart` to restart the service. If the service is not currently running, this command acts like `start`.
 * `status` to check the current status of the service.
   * This command prints one line to the console.

--- a/src/Core/ServiceWrapper/Main.cs
+++ b/src/Core/ServiceWrapper/Main.cs
@@ -607,6 +607,10 @@ namespace winsw
                     Stop();
                     return;
 
+                case "stopwait":
+                    StopWait();
+                    return;
+
                 case "restart":
                     Restart();
                     return;
@@ -815,6 +819,25 @@ namespace winsw
                 }
             }
 
+            void StopWait()
+            {
+                Log.Info("Stopping the service with id '" + descriptor.Id + "'");
+                if (s is null)
+                    ThrowNoSuchService();
+
+                if (s.Started)
+                    s.StopService();
+
+                while (s != null && s.Started)
+                {
+                    Log.Info("Waiting the service to stop...");
+                    Thread.Sleep(1000);
+                    s = svc.Select(descriptor.Id);
+                }
+
+                Log.Info("The service stopped.");
+            }
+
             void Restart()
             {
                 Log.Info("Restarting the service with id '" + descriptor.Id + "'");
@@ -984,6 +1007,7 @@ namespace winsw
   uninstall   uninstall the service
   start       start the service (must be installed before)
   stop        stop the service
+  stopwait    stop the service and wait until it's actually stopped
   restart     restart the service
   restart!    self-restart (can be called from child processes)
   status      check the current status of the service


### PR DESCRIPTION
The command is useful in uninstall scenarios, when the service needs to be stopped first.

It's better than `net stop <serviceId>` because the new `stopwait` command doesn't need to specify the actual service ID. I.e. it allows to keep the service ID in one place rather than two (config XML and uninstall script)