### PR TITLE
Properly request additional time for shutdown when `<waithint>` is set

### DIFF
--- a/src/Core/ServiceWrapper/Main.cs
+++ b/src/Core/ServiceWrapper/Main.cs
@@ -360,7 +360,6 @@ namespace winsw
                 Log.Debug("WaitForProcessToExit " + _process.Id + "+" + stopProcess.Id);
                 WaitForProcessToExit(_process);
                 WaitForProcessToExit(stopProcess);
-                SignalShutdownComplete();
             }
 
             // Stop extensions
@@ -422,12 +421,7 @@ namespace winsw
                 effectiveWaitHint = (int)_descriptor.WaitHint.TotalMilliseconds;
             }
 
-            IntPtr handle = ServiceHandle;
-            _wrapperServiceStatus.checkPoint++;
-            _wrapperServiceStatus.waitHint = effectiveWaitHint;
-            // WriteEvent("SignalShutdownPending " + wrapperServiceStatus.checkPoint + ":" + wrapperServiceStatus.waitHint);
-            _wrapperServiceStatus.currentState = (int)State.SERVICE_STOP_PENDING;
-            Advapi32.SetServiceStatus(handle, _wrapperServiceStatus);
+            RequestAdditionalTime(effectiveWaitHint);
         }
 
         private void SignalShutdownComplete()


### PR DESCRIPTION
- These `SetServiceStatus` calls always fail.
- `SignalShutdownComplete` doesn't need to be called `StopIt`.
- `SignalShutdownComplete` shall not be called before extensions shutdown complete.