### PR TITLE
Publish self-contained archives

### DIFF
--- a/eng/build.yml
+++ b/eng/build.yml
@@ -40,9 +40,10 @@ jobs:
       projects: src\WinSW.sln
       arguments: -c $(BuildConfiguration) -p:Version=$(BuildVersion)
   - script: |
-      dotnet publish -c $(BuildConfiguration) -f netcoreapp3.1 src\WinSW\WinSW.csproj -p:Version=$(BuildVersion)
-      dotnet publish -c $(BuildConfiguration) -f netcoreapp3.1 -r win-x64 src\WinSW\WinSW.csproj -p:PublishSingleFile=true -p:PublishTrimmed=true -p:Version=$(BuildVersion)
-      dotnet publish -c $(BuildConfiguration) -f netcoreapp3.1 -r win-x86 src\WinSW\WinSW.csproj -p:PublishSingleFile=true -p:PublishTrimmed=true -p:Version=$(BuildVersion)
+      dotnet publish -c $(BuildConfiguration) -f netcoreapp3.1 -r win-x64 src\WinSW\WinSW.csproj -p:Version=$(BuildVersion)
+      dotnet publish -c $(BuildConfiguration) -f netcoreapp3.1 -r win-x86 src\WinSW\WinSW.csproj -p:Version=$(BuildVersion)
+      dotnet publish -c $(BuildConfiguration) -f netcoreapp3.1 -r win-x64 src\WinSW\WinSW.csproj -p:PublishSingleFile=true -p:Version=$(BuildVersion)
+      dotnet publish -c $(BuildConfiguration) -f netcoreapp3.1 -r win-x86 src\WinSW\WinSW.csproj -p:PublishSingleFile=true -p:Version=$(BuildVersion)
     displayName: Build
   - task: DotNetCoreCLI@2
     displayName: Test
@@ -64,15 +65,18 @@ jobs:
   - publish: artifacts\WinSW.NET461.exe
     artifact: WinSW.NET461.exe_$(BuildConfiguration)
     displayName: Publish .NET 4.6.1
-  - publish: artifacts\WinSW.NETCore31.zip
-    artifact: WinSW.NETCore31.zip_$(BuildConfiguration)
-    displayName: Publish .NET Core
-  - publish: artifacts\WinSW.NETCore31.x64.exe
-    artifact: WinSW.NETCore31.x64.exe_$(BuildConfiguration)
-    displayName: Publish .NET Core x64
-  - publish: artifacts\WinSW.NETCore31.x86.exe
-    artifact: WinSW.NETCore31.x86.exe_$(BuildConfiguration)
-    displayName: Publish .NET Core x86
+  - publish: artifacts\WinSW.NETCore.x64.zip
+    artifact: WinSW.NETCore.x64.zip_$(BuildConfiguration)
+    displayName: Publish .NET Core x64 .zip
+  - publish: artifacts\WinSW.NETCore.x86.zip
+    artifact: WinSW.NETCore.x86.zip_$(BuildConfiguration)
+    displayName: Publish .NET Core x86 .zip
+  - publish: artifacts\WinSW.NETCore.x64.exe
+    artifact: WinSW.NETCore.x64.exe_$(BuildConfiguration)
+    displayName: Publish .NET Core x64 .exe
+  - publish: artifacts\WinSW.NETCore.x86.exe
+    artifact: WinSW.NETCore.x86.exe_$(BuildConfiguration)
+    displayName: Publish .NET Core x86 .exe
   - publish: $(Build.ArtifactStagingDirectory)\WinSW.$(BuildVersion).nupkg
     artifact: WinSW.nupkg_$(BuildConfiguration)
     displayName: Publish Nuget

--- a/src/WinSW/WinSW.csproj
+++ b/src/WinSW/WinSW.csproj
@@ -6,6 +6,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <PublishTrimmed>true</PublishTrimmed>
 
     <AssemblyTitle>Windows Service Wrapper</AssemblyTitle>
     <Description>Allows arbitrary process to run as a Windows service by wrapping it.</Description>
@@ -32,25 +33,17 @@
     <ProjectReference Include="..\WinSW.Plugins\WinSW.Plugins.csproj" />
   </ItemGroup>
 
-  <Target Name="PublishCoreZip" AfterTargets="Publish" Condition="'$(TargetFramework)' == 'netcoreapp3.1' and '$(RuntimeIdentifier)' == ''">
+  <Target Name="PublishCoreZip" AfterTargets="Publish" Condition="'$(TargetFramework)' == 'netcoreapp3.1' and '$(PublishSingleFile)' != 'true'">
 
     <MakeDir Directories="$(ArtifactsDir)" />
-    <ZipDirectory SourceDirectory="$(PublishDir)" DestinationFile="$(ArtifactsDir)WinSW.NETCore31.zip" Overwrite="true" />
+    <ZipDirectory SourceDirectory="$(PublishDir)" DestinationFile="$(ArtifactsDir)WinSW.NETCore.$(PlatformTarget).zip" Overwrite="true" />
 
   </Target>
 
-  <Target Name="PublishCoreExe" AfterTargets="Publish" Condition="'$(TargetFramework)' == 'netcoreapp3.1' and '$(RuntimeIdentifier)' != ''">
-
-    <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'win-x64'">
-      <IdentifierSuffix>x64</IdentifierSuffix>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'win-x86'">
-      <IdentifierSuffix>x86</IdentifierSuffix>
-    </PropertyGroup>
+  <Target Name="PublishCoreExe" AfterTargets="Publish" Condition="'$(TargetFramework)' == 'netcoreapp3.1' and '$(PublishSingleFile)' == 'true'">
 
     <MakeDir Directories="$(ArtifactsDir)" />
-    <Copy SourceFiles="$(PublishDir)$(TargetName).exe" DestinationFiles="$(ArtifactsDir)WinSW.NETCore31.$(IdentifierSuffix).exe" />
+    <Copy SourceFiles="$(PublishDir)$(TargetName).exe" DestinationFiles="$(ArtifactsDir)WinSW.NETCore.$(PlatformTarget).exe" />
 
   </Target>
 
@@ -58,7 +51,7 @@
   <Target Name="Merge" BeforeTargets="AfterBuild" Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
 
     <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">
-      <IdentifierSuffix>NET461</IdentifierSuffix>
+      <TargetFrameworkSuffix>NET461</TargetFrameworkSuffix>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -66,7 +59,7 @@
       <InputAssemblies>$(InputAssemblies) "$(OutDir)WinSW.Core.dll"</InputAssemblies>
       <InputAssemblies>$(InputAssemblies) "$(OutDir)WinSW.Plugins.dll"</InputAssemblies>
       <InputAssemblies>$(InputAssemblies) "$(OutDir)log4net.dll"</InputAssemblies>
-      <OutputAssembly>"$(ArtifactsDir)WinSW.$(IdentifierSuffix).exe"</OutputAssembly>
+      <OutputAssembly>"$(ArtifactsDir)WinSW.$(TargetFrameworkSuffix).exe"</OutputAssembly>
     </PropertyGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
Fixes #416 

Hold for #418 

Most users may not have the xxxx xxxx runtime installed. Therefore, I'm dropping the runtime-dependent archives and publish self-contained ones instead.

After #409 is implemented there will be no need to document which file should be renamed.