### PR TITLE
Support security descriptor string

### DIFF
--- a/doc/xmlConfigFile.md
+++ b/doc/xmlConfigFile.md
@@ -230,6 +230,17 @@ This affects the behaviour of the failure actions (see `<onfailure>` above).
 In other words, this is the duration in which you consider the service has been running successfully. 
 Defaults to 1 day.
 
+
+### Security descriptor
+
+The security descriptor string for the service in SDDL form.
+
+For more information, see [Security Descriptor Definition Language](https://docs.microsoft.com/windows/win32/secauthz/security-descriptor-definition-language).
+
+```xml
+<securtityDescriptor></securtityDescriptor>
+```
+
 ### Service account
 It is possible to specify the useraccount (and password) that the service will run as. To do this, specify a `<serviceaccount>` element like this:
 

--- a/examples/sample-allOptions.xml
+++ b/examples/sample-allOptions.xml
@@ -80,6 +80,14 @@ Their modification will not take affect without the service re-installation.
   <resetfailure>1 hour</resetfailure>
   -->
 
+  <!--
+    OPTION: securityDescriptor
+    The security descriptor string for the service in SDDL form.
+    For more information, see https://docs.microsoft.com/windows/win32/secauthz/security-descriptor-definition-language.
+  -->
+
+  <!--<securityDescriptor></securityDescriptor>-->
+
 <!--
 SECTION: Executable management
 -->

--- a/src/Core/ServiceWrapper/Main.cs
+++ b/src/Core/ServiceWrapper/Main.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Security.AccessControl;
 using System.ServiceProcess;
 using System.Text;
 using System.Threading;
@@ -675,6 +676,14 @@ namespace winsw
                     {
                         sc.ChangeConfig(descriptor.ResetFailureAfter, actions);
                     }
+                }
+
+                if (descriptor.SecurityDescriptor != null)
+                {
+                    RawSecurityDescriptor rawSecurityDescriptor = new RawSecurityDescriptor(descriptor.SecurityDescriptor);
+                    byte[] securityDescriptorBytes = new byte[rawSecurityDescriptor.BinaryLength];
+                    rawSecurityDescriptor.GetBinaryForm(securityDescriptorBytes, 0);
+                    Advapi32.SetServiceObjectSecurity(/*TODO*/default, SecurityInfos.DiscretionaryAcl, securityDescriptorBytes);
                 }
 
                 return;

--- a/src/Core/WinSWCore/Native/Advapi32.cs
+++ b/src/Core/WinSWCore/Native/Advapi32.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
+using System.Security.AccessControl;
 using System.Text;
 
 // ReSharper disable InconsistentNaming
@@ -277,6 +278,9 @@ namespace winsw.Native
 
         [DllImport(Advapi32LibraryName)]
         public static extern bool SetServiceStatus(IntPtr hServiceStatus, in SERVICE_STATUS lpServiceStatus);
+
+        [DllImport(Advapi32LibraryName)]
+        public static extern bool SetServiceObjectSecurity(IntPtr hService, SecurityInfos dwSecurityInformation, byte[] lpSecurityDescriptor);
 
         [DllImport(Advapi32LibraryName)]
         internal static extern uint LsaOpenPolicy(

--- a/src/Core/WinSWCore/ServiceDescriptor.cs
+++ b/src/Core/WinSWCore/ServiceDescriptor.cs
@@ -698,5 +698,7 @@ namespace winsw
                 return (ProcessPriorityClass)Enum.Parse(typeof(ProcessPriorityClass), p, true);
             }
         }
+
+        public string? SecurityDescriptor => SingleElement("securityDescriptor", true);
     }
 }

--- a/src/Core/WinSWCore/WinSWCore.csproj
+++ b/src/Core/WinSWCore/WinSWCore.csproj
@@ -18,6 +18,7 @@
     <!-- <PackageReference Include="Microsoft.Management.Infrastructure" Version="2.0.0" /> -->
     <PackageReference Include="System.Diagnostics.EventLog" Version="4.7.0" />
     <PackageReference Include="System.Management" Version="4.7.0" />
+    <PackageReference Include="System.Security.AccessControl" Version="4.7.0" />
   </ItemGroup>
 
   <!-- error NU1605: Detected package downgrade: log4net 2.0.8 -->


### PR DESCRIPTION
Fixes #329 

Hold for #392 

Possible property names:

- `<securtityDescriptor>`
- `<securtityDescriptorString>`
- `<securtityDescriptorSddl>`
- `<stringSecurtityDescriptor>`