### PR TITLE
Add a Gitter chat for the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ winsw: Windows service wrapper in less restrictive license
 [![Github All Releases](https://img.shields.io/github/downloads/kohsuke/winsw/total.svg)](https://github.com/kohsuke/winsw/releases)
 [![NuGet](https://img.shields.io/nuget/v/WinSW.svg)](https://www.nuget.org/packages/WinSW/)
 [![Build status](https://ci.appveyor.com/api/projects/status/i94752yal9iy77in?svg=true)](https://ci.appveyor.com/project/oleg-nenashev/winsw)
+[![Gitter](https://badges.gitter.im/winsw/winsw.svg)](https://gitter.im/winsw/winsw?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 WinSW is an executable binary, which can be used to wrap and manage a custom process as a Windows service.
 Once you download the installation package, you can rename `winsw.exe` to any name, e.g. `myService.exe`.


### PR DESCRIPTION
Fixes #211 . Chat URL: : https://gitter.im/winsw/winsw. It is the most straightforward way to address the issue, but we can add a more comprehensive structure of chats (e.g. develoer and user chats). No strong opinion there 

CC @NextTurn  