### PR TITLE
Add .NET 4.6.1 executables to the NuGet package

### DIFF
--- a/WinSW.nuspec
+++ b/WinSW.nuspec
@@ -27,7 +27,9 @@ More info about the wrapper is available in the projects GitHub repository.
   <files>
     <file src="artifacts\WinSW.NET2.exe" target="lib\net20-full\WinSW.NET2.exe" />
     <file src="artifacts\WinSW.NET4.exe" target="lib\net40-full\WinSW.NET4.exe" />
+    <file src="artifacts\WinSW.NET461.exe" target="lib\net461-full\WinSW.NET461.exe" />
     <file src="examples\sample-allOptions.xml" target="lib\net20-full\WinSW.NET2.xml" />
     <file src="examples\sample-allOptions.xml" target="lib\net40-full\WinSW.NET4.xml" />
+    <file src="examples\sample-allOptions.xml" target="lib\net461-full\WinSW.NET461.xml" />
   </files>
 </package>


### PR DESCRIPTION
Subj. Since we have an executable now, it is quite straightforward to publish it