### PR TITLE
Fix default domain name

### DIFF
--- a/src/Core/WinSWCore/Configuration/DefaultSettings.cs
+++ b/src/Core/WinSWCore/Configuration/DefaultSettings.cs
@@ -24,7 +24,7 @@ namespace winsw.Configuration
         // Installation
         public bool AllowServiceAcountLogonRight => false;
         public string? ServiceAccountPassword => null;
-        public string ServiceAccountUser => "NULL\\NULL";
+        public string? ServiceAccountUser => null;
         public List<Native.SC_ACTION> FailureActions => new List<Native.SC_ACTION>(0);
         public TimeSpan ResetFailureAfter => TimeSpan.FromDays(1);
 

--- a/src/Core/WinSWCore/Configuration/IWinSWConfiguration.cs
+++ b/src/Core/WinSWCore/Configuration/IWinSWConfiguration.cs
@@ -20,7 +20,7 @@ namespace winsw.Configuration
         // Installation
         bool AllowServiceAcountLogonRight { get; }
         string? ServiceAccountPassword { get; }
-        string ServiceAccountUser { get; }
+        string? ServiceAccountUser { get; }
         List<Native.SC_ACTION> FailureActions { get; }
         TimeSpan ResetFailureAfter { get; }
 

--- a/src/Core/WinSWCore/ServiceDescriptor.cs
+++ b/src/Core/WinSWCore/ServiceDescriptor.cs
@@ -634,19 +634,17 @@ namespace winsw
 
         protected string? AllowServiceLogon => GetServiceAccountPart("allowservicelogon");
 
-        // ReSharper disable once InconsistentNaming
-        protected string? serviceAccountDomain => GetServiceAccountPart("domain");
+        protected string? ServiceAccountDomain => GetServiceAccountPart("domain");
 
-        // ReSharper disable once InconsistentNaming
-        protected string? serviceAccountName => GetServiceAccountPart("user");
+        protected string? ServiceAccountName => GetServiceAccountPart("user");
 
         public string? ServiceAccountPassword => GetServiceAccountPart("password");
 
-        public string ServiceAccountUser => (serviceAccountDomain ?? "NULL") + @"\" + (serviceAccountName ?? "NULL");
+        public string? ServiceAccountUser => ServiceAccountName is null ? null : (ServiceAccountDomain ?? ".") + "\\" + ServiceAccountName;
 
         public bool HasServiceAccount()
         {
-            return !string.IsNullOrEmpty(serviceAccountDomain) && !string.IsNullOrEmpty(serviceAccountName);
+            return !string.IsNullOrEmpty(ServiceAccountName);
         }
 
         public bool AllowServiceAcountLogonRight


### PR DESCRIPTION
Fixes the bug mentioned in #121 
Closes #109 

I have no interest in blaming someone. Keep in mind the **NULL** in Windows docs refers to `NULL` in C, `nullptr` in C++, or `null` in C#/Java, etc.