### PR TITLE
Remove strong name signing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -239,8 +239,7 @@ orleans.codegen.cs
 
 # Including strong name files can present a security risk
 # (https://github.com/github/gitignore/pull/2483#issue-259490424)
-*.snk
-*.pfx
+#*.snk
 
 # Since there are multiple workflows, uncomment next line to ignore bower_components
 # (https://github.com/github/gitignore/pull/1529#issuecomment-104372622)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <DebugType>full</DebugType>
-    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)winsw_key.snk</AssemblyOriginatorKeyFile>
     <ArtifactsDir>$(MSBuildThisFileDirectory)artifacts\</ArtifactsDir>
   </PropertyGroup>
 

--- a/generate-key.ps1
+++ b/generate-key.ps1
@@ -1,3 +1,0 @@
-$files = Get-ChildItem -Path 'C:\Program Files (x86)\Microsoft SDKs\Windows\' -Filter 'sn.exe' -Recurse | Select-Object -Property FullName
-$files
-& $files[0].FullName -k winsw_key.snk

--- a/src/Core/ServiceWrapper/winsw.csproj
+++ b/src/Core/ServiceWrapper/winsw.csproj
@@ -13,7 +13,6 @@
     <Copyright>Copyright 2008-2016 Oleg Nenashev, CloudBees, Inc. and other contributors</Copyright>
     <RootNamespace>winsw</RootNamespace>
     <AssemblyName>WindowsService</AssemblyName>
-    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
 
   <ItemGroup>
@@ -101,7 +100,7 @@
 
     <PropertyGroup>
       <ILMerge>$(NuGetPackageRoot)ilmerge\3.0.29\tools\net452\ILMerge.exe</ILMerge>
-      <ILMergeArgs>/keyfile:"$(AssemblyOriginatorKeyFile)" /targetplatform:$(TargetPlatform) /out:$(OutputAssembly) $(InputAssemblies)</ILMergeArgs>
+      <ILMergeArgs>/targetplatform:$(TargetPlatform) /out:$(OutputAssembly) $(InputAssemblies)</ILMergeArgs>
       <ILMergeCommand>"$(ILMerge)" $(ILMergeArgs)</ILMergeCommand>
     </PropertyGroup>
 

--- a/src/Core/WinSWCore/WinSWCore.csproj
+++ b/src/Core/WinSWCore/WinSWCore.csproj
@@ -6,7 +6,6 @@
     <Nullable>enable</Nullable>
     <Version><!-- Populated by AppVeyor --></Version>
     <RootNamespace>winsw</RootNamespace>
-    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Plugins/RunawayProcessKiller/RunawayProcessKiller.csproj
+++ b/src/Plugins/RunawayProcessKiller/RunawayProcessKiller.csproj
@@ -7,7 +7,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Version><!-- Populated by AppVeyor --></Version>
     <RootNamespace>winsw.Plugins.RunawayProcessKiller</RootNamespace>
-    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Plugins/SharedDirectoryMapper/SharedDirectoryMapper.csproj
+++ b/src/Plugins/SharedDirectoryMapper/SharedDirectoryMapper.csproj
@@ -6,7 +6,6 @@
     <Nullable>enable</Nullable>
     <Version><!-- Populated by AppVeyor --></Version>
     <RootNamespace>winsw.Plugins.SharedDirectoryMapper</RootNamespace>
-    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes #435

~- Define `SIGN_ASSEMBLY` environment variable to `true` in release builds.~
~- Move key files to a subdirectory.~

We don't really strong-name assemblies at the moment.