### PR TITLE
Allowing for extra whitespace padding in the <arguments> xml entry

### DIFF
--- a/src/Core/ServiceWrapper/Main.cs
+++ b/src/Core/ServiceWrapper/Main.cs
@@ -8,6 +8,7 @@ using System.Runtime.InteropServices;
 using System.Security.AccessControl;
 using System.ServiceProcess;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 #if VNEXT
 using System.Threading.Tasks;
@@ -276,12 +277,11 @@ namespace winsw
                 startarguments += " " + _descriptor.Arguments;
             }
 
-            // Collapsing newlines, line returns, tabs and multiple spaces into a single
-            // space.  This allows users to pad the arguments in the xml for readability
-            // without breaking the application launching and keeps the log entries 
-            // compact.
-            startarguments = startarguments.Replace("\t", " ").Replace("\n", " ").Replace("\r", " ");
-            startarguments = string.Join(" ", startarguments.Split(new char[] {' '}, StringSplitOptions.RemoveEmptyEntries));
+            // Collapsing whitespace such as newlines, line returns, tabs and multiple 
+            // spaces into a single space.  This allows users to pad the arguments in 
+            // the xml for readability without breaking the application launching and 
+            // keeps the log entries compact.
+            startarguments = Regex.Replace(startarguments, @"\s+", " ");
 
             LogEvent("Starting " + _descriptor.Executable + ' ' + startarguments);
             Log.Info("Starting " + _descriptor.Executable + ' ' + startarguments);

--- a/src/Core/ServiceWrapper/Main.cs
+++ b/src/Core/ServiceWrapper/Main.cs
@@ -276,11 +276,11 @@ namespace winsw
                 startarguments += " " + _descriptor.Arguments;
             }
 
-            // Collapsing newlines, line returns and multiple spaces into a single
+            // Collapsing newlines, line returns, tabs and multiple spaces into a single
             // space.  This allows users to pad the arguments in the xml for readability
             // without breaking the application launching and keeps the log entries 
             // compact.
-            startarguments = startarguments.Replace("\n", " ").Replace("\r", " ");
+            startarguments = startarguments.Replace("\t", "").Replace("\n", " ").Replace("\r", " ");
             startarguments = string.Join(" ", startarguments.Split(new char[] {' '}, StringSplitOptions.RemoveEmptyEntries));
 
             LogEvent("Starting " + _descriptor.Executable + ' ' + startarguments);

--- a/src/Core/ServiceWrapper/Main.cs
+++ b/src/Core/ServiceWrapper/Main.cs
@@ -276,6 +276,11 @@ namespace winsw
                 startarguments += " " + _descriptor.Arguments;
             }
 
+            // Removing any newlines that may have been introduced into the xml for readability.
+            // and collapsing multiple empty spaces into one.
+            startarguments = startarguments.Replace("\n", "").Replace("\r", "");
+            startarguments = string.Join(" ", startarguments.Split(new char[] {' '}, StringSplitOptions.RemoveEmptyEntries));
+
             LogEvent("Starting " + _descriptor.Executable + ' ' + startarguments);
             Log.Info("Starting " + _descriptor.Executable + ' ' + startarguments);
 

--- a/src/Core/ServiceWrapper/Main.cs
+++ b/src/Core/ServiceWrapper/Main.cs
@@ -276,9 +276,11 @@ namespace winsw
                 startarguments += " " + _descriptor.Arguments;
             }
 
-            // Removing any newlines that may have been introduced into the xml for readability.
-            // and collapsing multiple empty spaces into one.
-            startarguments = startarguments.Replace("\n", "").Replace("\r", "");
+            // Collapsing newlines, line returns and multiple spaces into a single
+            // space.  This allows users to pad the arguments in the xml for readability
+            // without breaking the application launching and keeps the log entries 
+            // compact.
+            startarguments = startarguments.Replace("\n", " ").Replace("\r", " ");
             startarguments = string.Join(" ", startarguments.Split(new char[] {' '}, StringSplitOptions.RemoveEmptyEntries));
 
             LogEvent("Starting " + _descriptor.Executable + ' ' + startarguments);

--- a/src/Core/ServiceWrapper/Main.cs
+++ b/src/Core/ServiceWrapper/Main.cs
@@ -280,7 +280,7 @@ namespace winsw
             // space.  This allows users to pad the arguments in the xml for readability
             // without breaking the application launching and keeps the log entries 
             // compact.
-            startarguments = startarguments.Replace("\t", "").Replace("\n", " ").Replace("\r", " ");
+            startarguments = startarguments.Replace("\t", " ").Replace("\n", " ").Replace("\r", " ");
             startarguments = string.Join(" ", startarguments.Split(new char[] {' '}, StringSplitOptions.RemoveEmptyEntries));
 
             LogEvent("Starting " + _descriptor.Executable + ' ' + startarguments);


### PR DESCRIPTION
I want to use WinSW to setup 'swarm-client' to connect into Jenkins.  The swarm-client has a lot of configuration arguments, so it would be really helpful to pad the xml with newlines and whitespace for readability.  The code changes I'm proposing would collapse the whitespace, newlines and line returns down to a single whitespace so the process call works correctly and things report nicely in the logs.

Example xml: 
```
<service>
    <id>jenkinsswarmclient</id>
    <name>Jenkins Swarm Client (powered by WinSW)</name>
    <description>This service starts up the java swarm-client
                 to connect this computer as a jenkins slave node.</description>
    <executable>java</executable>
    <arguments>-jar "%BASE%\swarm-client.jar"
               -master https://jenkins.it.keysight.com  
               -username my-user 
               -password <redacted> 
               -deleteExistingClients 
               -fsroot C:\jenkins -labels "vsbuild windows" 
               -disableClientsUniqueId 
               -name Win-29 
               -mode exclusive 
               -executors 4 
               -description "swarm-client" 
               -retryBackOffStrategy exponential 
               -maxRetryInterval 5
    </arguments>
</service>
```