### PR TITLE
Feature/eliminate newlines

### DIFF
--- a/src/Core/ServiceWrapper/Main.cs
+++ b/src/Core/ServiceWrapper/Main.cs
@@ -8,6 +8,7 @@ using System.Runtime.InteropServices;
 using System.Security.AccessControl;
 using System.ServiceProcess;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 #if VNEXT
 using System.Threading.Tasks;
@@ -276,12 +277,11 @@ namespace winsw
                 startarguments += " " + _descriptor.Arguments;
             }
 
-            // Collapsing newlines, line returns, tabs and multiple spaces into a single
-            // space.  This allows users to pad the arguments in the xml for readability
-            // without breaking the application launching and keeps the log entries 
-            // compact.
-            startarguments = startarguments.Replace("\t", " ").Replace("\n", " ").Replace("\r", " ");
-            startarguments = string.Join(" ", startarguments.Split(new char[] {' '}, StringSplitOptions.RemoveEmptyEntries));
+            // Collapsing whitespace such as newlines, line returns, tabs and multiple 
+            // spaces into a single space.  This allows users to pad the arguments in 
+            // the xml for readability without breaking the application launching and 
+            // keeps the log entries compact.
+            startarguments = Regex.Replace(startarguments, @"\s+", " ");
 
             LogEvent("Starting " + _descriptor.Executable + ' ' + startarguments);
             Log.Info("Starting " + _descriptor.Executable + ' ' + startarguments);

--- a/src/Core/ServiceWrapper/Main.cs
+++ b/src/Core/ServiceWrapper/Main.cs
@@ -276,11 +276,11 @@ namespace winsw
                 startarguments += " " + _descriptor.Arguments;
             }
 
-            // Collapsing newlines, line returns and multiple spaces into a single
+            // Collapsing newlines, line returns, tabs and multiple spaces into a single
             // space.  This allows users to pad the arguments in the xml for readability
             // without breaking the application launching and keeps the log entries 
             // compact.
-            startarguments = startarguments.Replace("\n", " ").Replace("\r", " ");
+            startarguments = startarguments.Replace("\t", "").Replace("\n", " ").Replace("\r", " ");
             startarguments = string.Join(" ", startarguments.Split(new char[] {' '}, StringSplitOptions.RemoveEmptyEntries));
 
             LogEvent("Starting " + _descriptor.Executable + ' ' + startarguments);

--- a/src/Core/ServiceWrapper/Main.cs
+++ b/src/Core/ServiceWrapper/Main.cs
@@ -280,7 +280,7 @@ namespace winsw
             // Converting newlines, line returns, tabs into a single 
             // space. This allows users to provide multi-line arguments
             // in the xml for readability.
-            startarguments = Regex.Replace(startarguments, @"[\n\r\t]+", " ");
+            startarguments = Regex.Replace(startarguments, @"\s*[\n\r\t]+\s*", " ");
 
             LogEvent("Starting " + _descriptor.Executable + ' ' + startarguments);
             Log.Info("Starting " + _descriptor.Executable + ' ' + startarguments);

--- a/src/Core/ServiceWrapper/Main.cs
+++ b/src/Core/ServiceWrapper/Main.cs
@@ -276,6 +276,11 @@ namespace winsw
                 startarguments += " " + _descriptor.Arguments;
             }
 
+            // Removing any newlines that may have been introduced into the xml for readability.
+            // and collapsing multiple empty spaces into one.
+            startarguments = startarguments.Replace("\n", "").Replace("\r", "");
+            startarguments = string.Join(" ", startarguments.Split(new char[] {' '}, StringSplitOptions.RemoveEmptyEntries));
+
             LogEvent("Starting " + _descriptor.Executable + ' ' + startarguments);
             Log.Info("Starting " + _descriptor.Executable + ' ' + startarguments);
 

--- a/src/Core/ServiceWrapper/Main.cs
+++ b/src/Core/ServiceWrapper/Main.cs
@@ -276,9 +276,11 @@ namespace winsw
                 startarguments += " " + _descriptor.Arguments;
             }
 
-            // Removing any newlines that may have been introduced into the xml for readability.
-            // and collapsing multiple empty spaces into one.
-            startarguments = startarguments.Replace("\n", "").Replace("\r", "");
+            // Collapsing newlines, line returns and multiple spaces into a single
+            // space.  This allows users to pad the arguments in the xml for readability
+            // without breaking the application launching and keeps the log entries 
+            // compact.
+            startarguments = startarguments.Replace("\n", " ").Replace("\r", " ");
             startarguments = string.Join(" ", startarguments.Split(new char[] {' '}, StringSplitOptions.RemoveEmptyEntries));
 
             LogEvent("Starting " + _descriptor.Executable + ' ' + startarguments);

--- a/src/Core/ServiceWrapper/Main.cs
+++ b/src/Core/ServiceWrapper/Main.cs
@@ -280,7 +280,7 @@ namespace winsw
             // space.  This allows users to pad the arguments in the xml for readability
             // without breaking the application launching and keeps the log entries 
             // compact.
-            startarguments = startarguments.Replace("\t", "").Replace("\n", " ").Replace("\r", " ");
+            startarguments = startarguments.Replace("\t", " ").Replace("\n", " ").Replace("\r", " ");
             startarguments = string.Join(" ", startarguments.Split(new char[] {' '}, StringSplitOptions.RemoveEmptyEntries));
 
             LogEvent("Starting " + _descriptor.Executable + ' ' + startarguments);

--- a/src/Core/ServiceWrapper/Main.cs
+++ b/src/Core/ServiceWrapper/Main.cs
@@ -280,7 +280,7 @@ namespace winsw
             // Converting newlines, line returns, tabs into a single 
             // space. This allows users to provide multi-line arguments
             // in the xml for readability.
-            startarguments = Regex.Replace(startarguments, @"\s*[\n\r\t]+\s*", " ");
+            startarguments = Regex.Replace(startarguments, @"\s*[\n\r]+\s*", " ");
 
             LogEvent("Starting " + _descriptor.Executable + ' ' + startarguments);
             Log.Info("Starting " + _descriptor.Executable + ' ' + startarguments);

--- a/src/Core/ServiceWrapper/Main.cs
+++ b/src/Core/ServiceWrapper/Main.cs
@@ -277,11 +277,10 @@ namespace winsw
                 startarguments += " " + _descriptor.Arguments;
             }
 
-            // Collapsing whitespace such as newlines, line returns, tabs and multiple 
-            // spaces into a single space.  This allows users to pad the arguments in 
-            // the xml for readability without breaking the application launching and 
-            // keeps the log entries compact.
-            startarguments = Regex.Replace(startarguments, @"\s+", " ");
+            // Converting newlines, line returns, tabs into a single 
+            // space. This allows users to provide multi-line arguments
+            // in the xml for readability.
+            startarguments = Regex.Replace(startarguments, @"[\n\r\t]+", " ");
 
             LogEvent("Starting " + _descriptor.Executable + ' ' + startarguments);
             Log.Info("Starting " + _descriptor.Executable + ' ' + startarguments);


### PR DESCRIPTION
Hi,

I created a branch that would just remove newlines, line returns and tabs from the program arguments.  In reviewing the log files, I could see no difference between this code and the one that collapsed whitespace.  I intentionally inserted multiple whitespaces in both quoted and unquoted sections of the arguments, and only saw a single whitespace in the event log.  When testing, I had inserted a event log entry stating that newlines were being removed just to make sure the new code was actually running, and I was seeing that log message.  So, I feel pretty confident that somewhere else in the chain, and it's likely not code that either you or I own, there is a call to collapse whitespace.  I could even be the log viewer that doing the collapsing.

As I'm not seeing any observable differences between the code with the call to collapse whitespace and the one that does't, I'll be very happy to see either in a new release.  So, feel free to accept whichever of my pull requests you feel is the better option and deny the other.

Replaces #479 