### PR TITLE
Remove <stopparentprocessfirst> setting and fix process termination

### DIFF
--- a/doc/extensions/runawayProcessKiller.md
+++ b/doc/extensions/runawayProcessKiller.md
@@ -35,8 +35,6 @@ The extension can be configured via the [XML configuration file](../xmlConfigFil
            After the timeout WinSW will try to force kill the process.
       -->
       <stopTimeout>5000</stopTimeout>
-      <!-- If true, the parent process will be terminated first if the runaway process gets terminated. -->
-      <stopParentFirst>false</stopParentFirst>
     </extension>
   </extensions>
 </service>

--- a/doc/xmlConfigFile.md
+++ b/doc/xmlConfigFile.md
@@ -352,13 +352,3 @@ Possible values are `idle`, `belownormal`, `normal`, `abovenormal`, `high`, `rea
 Specifying a priority higher than normal has unintended consequences.
 For more information, see [ProcessPriorityClass Enumeration](https://docs.microsoft.com/dotnet/api/system.diagnostics.processpriorityclass) in .NET docs.
 This feature is intended primarily to launch a process in a lower priority so as not to interfere with the computer's interactive usage.
-
-### Stop parent process first
-
-Optionally specify the order of service shutdown. 
-If `true`, the parent process is shutdown first. 
-This is useful when the main process is a console, which can respond to Ctrl+C command and will gracefully shutdown child processes.
-
-```xml
-<stopparentprocessfirst>true</stopparentprocessfirst>
-```

--- a/examples/sample-allOptions.xml
+++ b/examples/sample-allOptions.xml
@@ -132,13 +132,6 @@ SECTION: Executable management
     Default value: 15 seconds
   -->
   <stoptimeout>15 sec</stoptimeout>
-    
-  <!--
-    OPTION: stopparentprocessfirst
-    If set, WinSW will terminate the parent process before stopping the children.
-    Default value: false
-  -->
-  <stopparentprocessfirst>false</stopparentprocessfirst>
   
   
   <!-- 

--- a/src/Core/ServiceWrapper/WrapperService.cs
+++ b/src/Core/ServiceWrapper/WrapperService.cs
@@ -305,7 +305,7 @@ namespace winsw
                 try
                 {
                     Log.Debug("ProcessKill " + _process.Id);
-                    ProcessHelper.StopProcessAndChildren(_process, _descriptor.StopTimeout, _descriptor.StopParentProcessFirst);
+                    ProcessHelper.StopProcessTree(_process, _descriptor.StopTimeout);
                     ExtensionManager.FireOnProcessTerminated(_process);
                 }
                 catch (InvalidOperationException)

--- a/src/Core/WinSWCore/Configuration/DefaultSettings.cs
+++ b/src/Core/WinSWCore/Configuration/DefaultSettings.cs
@@ -35,7 +35,6 @@ namespace winsw.Configuration
         public string WorkingDirectory => Path.GetDirectoryName(ExecutablePath)!;
         public ProcessPriorityClass Priority => ProcessPriorityClass.Normal;
         public TimeSpan StopTimeout => TimeSpan.FromSeconds(15);
-        public bool StopParentProcessFirst => false;
 
         // Service management
         public ServiceStartMode StartMode => ServiceStartMode.Automatic;

--- a/src/Core/WinSWCore/Configuration/IWinSWConfiguration.cs
+++ b/src/Core/WinSWCore/Configuration/IWinSWConfiguration.cs
@@ -32,7 +32,6 @@ namespace winsw.Configuration
         string WorkingDirectory { get; }
         ProcessPriorityClass Priority { get; }
         TimeSpan StopTimeout { get; }
-        bool StopParentProcessFirst { get; }
 
         // Service management
         ServiceStartMode StartMode { get; }

--- a/src/Core/WinSWCore/ServiceDescriptor.cs
+++ b/src/Core/WinSWCore/ServiceDescriptor.cs
@@ -677,20 +677,6 @@ namespace winsw
         /// </summary>
         public TimeSpan StopTimeout => SingleTimeSpanElement(dom, "stoptimeout", Defaults.StopTimeout);
 
-        public bool StopParentProcessFirst
-        {
-            get
-            {
-                var value = SingleElement("stopparentprocessfirst", true);
-                if (bool.TryParse(value, out bool result))
-                {
-                    return result;
-                }
-
-                return Defaults.StopParentProcessFirst;
-            }
-        }
-
         /// <summary>
         /// Desired process priority or null if not specified.
         /// </summary>

--- a/src/Core/WinSWCore/Util/ProcessHelper.cs
+++ b/src/Core/WinSWCore/Util/ProcessHelper.cs
@@ -114,25 +114,13 @@ namespace winsw.Util
         /// </summary>
         /// <param name="pid">Process PID</param>
         /// <param name="stopTimeout">Stop timeout (for each process)</param>
-        /// <param name="stopParentProcessFirst">If enabled, the perent process will be terminated before its children on all levels</param>
-        public static void StopProcessAndChildren(Process process, TimeSpan stopTimeout, bool stopParentProcessFirst)
+        public static void StopProcessTree(Process process, TimeSpan stopTimeout)
         {
-            if (!stopParentProcessFirst)
-            {
-                foreach (Process child in GetChildProcesses(process.Id))
-                {
-                    StopProcessAndChildren(child, stopTimeout, stopParentProcessFirst);
-                }
-            }
-
             StopProcess(process, stopTimeout);
 
-            if (stopParentProcessFirst)
+            foreach (Process child in GetChildProcesses(process.Id))
             {
-                foreach (Process child in GetChildProcesses(process.Id))
-                {
-                    StopProcessAndChildren(child, stopTimeout, stopParentProcessFirst);
-                }
+                StopProcessTree(child, stopTimeout);
             }
         }
 

--- a/src/Plugins/RunawayProcessKiller/RunawayProcessKillerExtension.cs
+++ b/src/Plugins/RunawayProcessKiller/RunawayProcessKillerExtension.cs
@@ -25,11 +25,6 @@ namespace winsw.Plugins.RunawayProcessKiller
         public TimeSpan StopTimeout { get; private set; }
 
         /// <summary>
-        /// If true, the parent process will be terminated first if the runaway process gets terminated.
-        /// </summary>
-        public bool StopParentProcessFirst { get; private set; }
-
-        /// <summary>
         /// If true, the runaway process will be checked for the WinSW environment variable before termination.
         /// This option is not documented AND not supposed to be used by users.
         /// </summary>
@@ -49,12 +44,11 @@ namespace winsw.Plugins.RunawayProcessKiller
         }
 
 #pragma warning disable CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
-        public RunawayProcessKillerExtension(string pidfile, int stopTimeoutMs = 5000, bool stopParentFirst = false, bool checkWinSWEnvironmentVariable = true)
+        public RunawayProcessKillerExtension(string pidfile, int stopTimeoutMs = 5000, bool checkWinSWEnvironmentVariable = true)
 #pragma warning restore CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
         {
             this.Pidfile = pidfile;
             this.StopTimeout = TimeSpan.FromMilliseconds(stopTimeoutMs);
-            this.StopParentProcessFirst = stopParentFirst;
             this.CheckWinSWEnvironmentVariable = checkWinSWEnvironmentVariable;
         }
 
@@ -185,7 +179,6 @@ namespace winsw.Plugins.RunawayProcessKiller
             // TODO: a better parser API for types would be useful
             Pidfile = XmlHelper.SingleElement(node, "pidfile", false)!;
             StopTimeout = TimeSpan.FromMilliseconds(int.Parse(XmlHelper.SingleElement(node, "stopTimeout", false)!));
-            StopParentProcessFirst = bool.Parse(XmlHelper.SingleElement(node, "stopParentFirst", false)!);
             ServiceId = descriptor.Id;
             // TODO: Consider making it documented
             var checkWinSWEnvironmentVariable = XmlHelper.SingleElement(node, "checkWinSWEnvironmentVariable", true);
@@ -276,7 +269,7 @@ namespace winsw.Plugins.RunawayProcessKiller
             bldr.Append(proc);
 
             Logger.Warn(bldr.ToString());
-            ProcessHelper.StopProcessAndChildren(proc, this.StopTimeout, this.StopParentProcessFirst);
+            ProcessHelper.StopProcessTree(proc, this.StopTimeout);
         }
 
         /// <summary>

--- a/src/Plugins/RunawayProcessKiller/sampleConfig.xml
+++ b/src/Plugins/RunawayProcessKiller/sampleConfig.xml
@@ -14,8 +14,6 @@
 		  <pidfile>%BASE%\pid.txt</pidfile>
       <!-- Defines the process termination timeout in milliseconds. This timeout will be applied multiple times for each child process. -->
       <stopTimeout>5000</stopTimeout>
-      <!-- If true, the parent process will be terminated first if the runaway process gets terminated. -->
-      <stopParentFirst>false</stopParentFirst>
     </extension>
   </extensions>
 </service>

--- a/src/Test/winswTests/Extensions/RunawayProcessKillerTest.cs
+++ b/src/Test/winswTests/Extensions/RunawayProcessKillerTest.cs
@@ -33,7 +33,6 @@ $@"<service>
     <extension enabled=""true"" className=""{testExtension}"" id=""killRunawayProcess"">
       <pidfile>foo/bar/pid.txt</pidfile>
       <stopTimeout>5000</stopTimeout>
-      <stopParentFirst>true</stopParentFirst>
     </extension>
   </extensions>
 </service>";
@@ -52,7 +51,6 @@ $@"<service>
             Assert.IsNotNull(extension, "RunawayProcessKillerExtension should be loaded");
             Assert.AreEqual("foo/bar/pid.txt", extension.Pidfile, "Loaded PID file path is not equal to the expected one");
             Assert.AreEqual(5000, extension.StopTimeout.TotalMilliseconds, "Loaded Stop Timeout is not equal to the expected one");
-            Assert.AreEqual(true, extension.StopParentProcessFirst, "Loaded StopParentFirst is not equal to the expected one");
         }
 
         [Test]
@@ -110,7 +108,7 @@ $@"<service>
                 if (!proc.HasExited)
                 {
                     Console.Error.WriteLine("Test: Killing runaway process with ID=" + proc.Id);
-                    ProcessHelper.StopProcessAndChildren(proc, TimeSpan.FromMilliseconds(100), false);
+                    ProcessHelper.StopProcessTree(proc, TimeSpan.FromMilliseconds(100));
                     if (!proc.HasExited)
                     {
                         // The test is failed here anyway, but we add additional diagnostics info

--- a/src/Test/winswTests/ServiceDescriptorTests.cs
+++ b/src/Test/winswTests/ServiceDescriptorTests.cs
@@ -137,23 +137,6 @@ $@"<service>
         }
 
         [Test]
-        public void StopParentProcessFirstIsFalseByDefault()
-        {
-            Assert.That(_extendedServiceDescriptor.StopParentProcessFirst, Is.False);
-        }
-
-        [Test]
-        public void CanParseStopParentProcessFirst()
-        {
-            const string seedXml = "<service>"
-                                   + "<stopparentprocessfirst>true</stopparentprocessfirst>"
-                                   + "</service>";
-            var serviceDescriptor = ServiceDescriptor.FromXML(seedXml);
-
-            Assert.That(serviceDescriptor.StopParentProcessFirst, Is.True);
-        }
-
-        [Test]
         public void CanParseStopTimeout()
         {
             const string seedXml = "<service>"

--- a/src/Test/winswTests/Util/ConfigXmlBuilder.cs
+++ b/src/Test/winswTests/Util/ConfigXmlBuilder.cs
@@ -116,7 +116,6 @@ namespace winswTests.Util
             str.AppendFormat("    <extension enabled=\"{0}\" className=\"{1}\" id=\"{2}\">\n", new object[] { enabled, fullyQualifiedExtensionName, extensionId });
             str.AppendFormat("      <pidfile>{0}</pidfile>\n", ext.Pidfile);
             str.AppendFormat("      <stopTimeout>{0}</stopTimeout>\n", ext.StopTimeout.TotalMilliseconds);
-            str.AppendFormat("      <stopParentFirst>{0}</stopParentFirst>\n", ext.StopParentProcessFirst);
             str.AppendFormat("      <checkWinSWEnvironmentVariable>{0}</checkWinSWEnvironmentVariable>\n", ext.CheckWinSWEnvironmentVariable);
             str.Append("    </extension>\n");
             ExtensionXmls.Add(str.ToString());


### PR DESCRIPTION
Fixes #95 
Fixes #115 
Fixes #123 
Fixes #245 
Fixes #283 
Fixes #295 

Verified that the Java shutdown hook is triggered with @lafual's codes in https://github.com/winsw/winsw/issues/283#issuecomment-401624379.

Stopping child processes first never ever works. **The Console Window Host (conhost.exe) does not have a console.** It's a host process for the console **window**.

---

~Closes #174~
~Closes #262~
~Closes #304~

This part was excluded from this PR.

---

https://github.com/winsw/winsw/issues/108#issuecomment-172876016

> actually writing a service is not rocket science

Writing a service is not rocket science, writing a service wrapper is, no?