### PR TITLE
Enable system default TLS versions when targeting .NET Framework 4.6.1

### DIFF
--- a/src/Core/WinSWCore/Download.cs
+++ b/src/Core/WinSWCore/Download.cs
@@ -36,9 +36,12 @@ namespace winsw
 
         public string ShortId => $"(download from {From})";
 
-#if !VNEXT
         static Download()
         {
+#if NET461
+            // If your app runs on .NET Framework 4.7 or later versions, but targets an earlier version
+            AppContext.SetSwitch("Switch.System.Net.DontEnableSystemDefaultTlsVersions", false);
+#elif !VNEXT
             const SecurityProtocolType Tls12 = (SecurityProtocolType)0x00000C00;
             const SecurityProtocolType Tls11 = (SecurityProtocolType)0x00000300;
 
@@ -55,8 +58,8 @@ namespace winsw
                     Logger.Info("TLS 1.1/1.2 disabled");
                 }
             }
-        }
 #endif
+        }
 
         // internal
         public Download(


### PR DESCRIPTION
See jenkinsci/windows-slave-installer-module#25 for background.

This should enable TLS 1.3 on newer Windows versions.