### PR TITLE
Cleanup and restructure the README page

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Binaries are available [here](https://repo.jenkins-ci.org/releases/com/sun/winsw
 
 ## Usage
 
-WinSW is being managed by configuration files: [Main XML configuration f,ile](doc/xmlConfigFile.md) and [EXE configuration file](doc/exeConfigFile.md).
+WinSW is being managed by configuration files: [Main XML configuration file](doc/xmlConfigFile.md) and [EXE configuration file](doc/exeConfigFile.md).
 
 Your renamed *WinSW.exe* binary also accepts the following commands:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# WinSW: Windows Service Wrapper in less restrictive license
+# Windows Service Wrapper in less restrictive license
 
 [![Github All Releases](https://img.shields.io/github/downloads/winsw/winsw/total?style=flat-square)](https://github.com/winsw/winsw/releases)
 [![NuGet](https://img.shields.io/nuget/v/WinSW?style=flat-square)](https://www.nuget.org/packages/WinSW/)
@@ -17,7 +17,7 @@ See the [project manifest](MANIFEST.md).
 
 WinSW offers executables for .NET Framework 2.0, 4.0 and 4.6.1.
 It can run on Windows platforms which have these versions of .NET framework installed.
-For systems without .NET Framework, the project provides native 64bit and 32bit executables which are based on .NET Core 3.1.
+For systems without .NET Framework, the project provides native 64-bit and 32-bit executables which are based on .NET Core 3.1.
 
 More executables can be added upon request.
 
@@ -72,8 +72,8 @@ Developer documentation:
 ## Contributing
 
 Contributions are welcome!
-No Clontributor Licence Agreement is needed, just submit your pull requests.
-See [the contributor guidelines](./CONTRIBUTING.md) for more information and guidelines.
+No Contributor License Agreement is needed, just submit your pull requests.
+See the [contributing guidelines](./CONTRIBUTING.md) for more information.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ See the [project manifest](MANIFEST.md).
 ## Supported platforms
 
 WinSW offers executables for .NET Framework 2.0, 4.0 and 4.6.1.
-It can run on Windows platforms which have these versions of .NET framework installed.
+It can run on Windows platforms which have these versions of .NET Framework installed.
 For systems without .NET Framework, the project provides native 64-bit and 32-bit executables which are based on .NET Core 3.1.
 
 More executables can be added upon request.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# winsw: Windows Service Wrapper in less restrictive license
+# WinSW: Windows Service Wrapper in less restrictive license
 
 [![Github All Releases](https://img.shields.io/github/downloads/winsw/winsw/total?style=flat-square)](https://github.com/winsw/winsw/releases)
 [![NuGet](https://img.shields.io/nuget/v/WinSW?style=flat-square)](https://www.nuget.org/packages/WinSW/)
@@ -13,16 +13,27 @@ Once you download the installation package, you can rename *WinSW.exe* to any na
 
 See the [project manifest](MANIFEST.md).
 
+## Supported platforms
+
+WinSW offers executables for .NET Framework 2.0, 4.0 and 4.6.1.
+It can run on Windows platforms which have these versions of .NET framework installed.
+For systems without .NET Framework, the project provides native 64bit and 32bit executables which are based on .NET Core 3.1.
+
+More executables can be added upon request.
+
 ## Download
 
-Starting from WinSW v2, the releases are being hosted on [GitHub](https://github.com/winsw/winsw/releases) and [NuGet](https://www.nuget.org/packages/WinSW/).
+WinSW binaries are available on [GitHub Releases](https://github.com/winsw/winsw/releases) and [NuGet](https://www.nuget.org/packages/WinSW/).
 
-Due to historical reasons, the project also uses the [Jenkins](https://jenkins.io/) Maven repository as a secondary source. 
-Binaries are available [here](https://repo.jenkins-ci.org/releases/com/sun/winsw/winsw/). 
+Alternative sources:
+
+* [Maven packaging](https://github.com/jenkinsci/winsw-maven-packaging) for executables, hosted by the [Jenkins project](https://jenkins.io/). 
+Binaries are available [here](https://repo.jenkins-ci.org/releases/com/sun/winsw/winsw/).
+* [Puppet](./doc/puppetWinSW.md), currently outdated (WinSW 1.x). Binaries are available on [Puppet Forge](https://forge.puppet.com/kenmaglio/winsw)
 
 ## Usage
 
-WinSW is being managed by configuration files: [Main XML configuration file](doc/xmlConfigFile.md) and [EXE configuration file](doc/exeConfigFile.md).
+WinSW is being managed by configuration files: [Main XML configuration f,ile](doc/xmlConfigFile.md) and [EXE configuration file](doc/exeConfigFile.md).
 
 Your renamed *WinSW.exe* binary also accepts the following commands:
 
@@ -37,14 +48,6 @@ Your renamed *WinSW.exe* binary also accepts the following commands:
     * `NonExistent` indicates the service is not currently installed
     * `Started` to indicate the service is currently running
     * `Stopped` to indicate that the service is installed but not currently running.
-
-## Supported .NET versions
-
-### WinSW v2
-
-WinSW v2 offers two executables, which declare .NET Frameworks 2.0 and 4.0 as targets.
-More executables can be added on-demand.
-Please create an issue if you need such executables.
 
 ## Documentation
 
@@ -66,20 +69,11 @@ Developer documentation:
 
 * [Developer guide](DEVELOPER.md)
 
-## Release lines
+## Contributing
 
-### WinSW v2
-
-This is a new baseline of WinSW with several major changes:
-* Major documentation rework and update
-* New executable package targeting the .NET Framework 4.0. .NET Framework 2.0 is still supported.
-* [Extension engine](doc/extensions/extensions.md), which allows extending the wrapper's behavior. And a couple of extensions for it (Shared Directory Mapper, Runaway Process Killer)
-* New release hosting: GitHub and NuGet
-* Migration of the logging subsystem to Apache log4net
-* Bugfixes
-
-The version v2 is **fully compatible** with the v1 configuration file format, 
-  hence the upgrade procedure just requires replacement of the executable file.
+Contributions are welcome!
+No Clontributor Licence Agreement is needed, just submit your pull requests.
+See [the contributor guidelines](./CONTRIBUTING.md) for more information and guidelines.
 
 ## License
 


### PR DESCRIPTION
This change continues https://github.com/winsw/winsw/pull/458 and updates Wiki even further.:

* Documentation for release lines is removed. WinSW 2.x is 4 years old, and it is compatible with WinSW 1.x. I do not think we need to spend any space on that anymore
* Move supported platforms up, update the text to reflect the actual state
* Add Contributing section