### PR TITLE
Always set process priority if specified

### DIFF
--- a/src/Core/WinSWCore/Util/ProcessHelper.cs
+++ b/src/Core/WinSWCore/Util/ProcessHelper.cs
@@ -183,7 +183,7 @@ namespace winsw.Util
             processToStart.Start();
             Logger.Info("Started process " + processToStart.Id);
 
-            if (priority != null && priority.Value != ProcessPriorityClass.Normal)
+            if (priority != null)
             {
                 processToStart.PriorityClass = priority.Value;
             }


### PR DESCRIPTION
Fixes #169 

According to the docs:

> By default, the priority class of a process is NORMAL_PRIORITY_CLASS. Use the CreateProcess function to specify the priority class of a child process when you create it. If the calling process is IDLE_PRIORITY_CLASS or BELOW_NORMAL_PRIORITY_CLASS, the new process will inherit this class.