### PR TITLE
Revise the installation guide

### DIFF
--- a/doc/exeConfigFile.md
+++ b/doc/exeConfigFile.md
@@ -3,7 +3,5 @@
 In addition to the [XML configuration file](xmlConfigFile.md), WinSW uses a standard .NET *WinSW.exe.config* file, which allows setting up some custom settings.
 
 Use-cases:
-* Declaring compatibility with newer .NET versions (see the [Installation guide](installation.md))
-* Managing custom behavior for the offline mode (see the [Installation guide](installation.md))
 * Managing Logging levels of log4j
 * etc.

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -7,14 +7,10 @@ This page provides WinSW installation guidelines for different cases.
 In order to setup WinSW, you commonly need to perform the following steps:
 
 1. Take *WinSW.exe* from the distribution, and rename it to your taste (such as *myapp.exe*)
-1. Write *myapp.xml* (see [XML config file specification](xmlConfigFile.md) for more details)
+1. Write *myapp.xml* (see the [XML config file specification](xmlConfigFile.md) for more details)
 1. Place those two files side by side, because that's how WinSW discovers its configuration.
 1. Run `myapp.exe install <OPTIONS>` in order to install the service wrapper.
-1. Optional - Perform additional configuration in the Windows Service Manager.
-1. Optional - Perform extra configurations if required (guidelines are available below).
-   * Declare that the executable is compatible with .NET 4 or above (**for WinSW v1 only**)
-   * Enable the WinSW offline mode
-1. Run the service from the Windows Service Manager.
+1. Run `myapp.exe start` to start the service.
 
 There are some details for each step available below.
 
@@ -53,45 +49,3 @@ Beyond these error codes, all the non-zero exit code should be assumed as a fail
 
 The Installer can be also started with the `/p` option.
 In such case it will prompt for an account name and password, which should be used as a service account.
-
-### Step 4. Windows Service Manager
-
-Once the service is installed, you can start it from Windows Service Manager.
-If you open `Properties` for the service, you can also configure how the service should be launched. 
-
-In particular, the following option can be set up:
-
-* Service automatic startup on the Windows startup
-* User or system account, under which the service runs
-* Recovery options (how Windows recovers the service if it dies due to whatever reason)
-
-In addition to the service manager, it is possible to make some additional configurations in the `Windows Registry Editor`.
-
-Once the start button is clicked, Windows will start *myapp.exe*, 
-  then *myapp.exe* will launch the executable specified in the configuration file (Java in this case). 
-  If this process dies, *myapp.exe* will exit itself, and the service will be considered stopped.
-
-## Extra configuration options
-
-### Making WinSW v1 compatible with .NET runtime 4.0+
-
-**IMPORTANT:** *Starting from WinSW v2 the release offers a new binary, which targets the .NET Framework 4.0.
-Such configuration is no longer required.*
-
-Modern versions of Windows (e.g. Windows Server 2012 or Windows 10) do not ship with .NET Framework 2.0, which is what *WinSW.exe* is built against. 
-This is because unlike Java, where a newer runtime can host apps developed against earlier runtime, .NET apps need version specific runtimes.
-
-One way to deal with this is to ensure that .NET Framework 2.0 is installed through your installer, but another way is to declare that *WinSW.exe* can be hosted on .NET Framework 4.0 by creating an app config file *WinSW.exe.config*.
-
-```xml
-<configuration>
-  <startup>
-    <supportedRuntime version="v2.0.50727" />
-    <supportedRuntime version="v4.0" />
-  </startup>
-</configuration>
-```
-
-The way the runtime finds this file is by naming convention, so don't forget to rename a file based on your actual executable name (e.g. *myapp.exe*). 
-For more information, see [How to: Configure an App to Support .NET Framework 4 or later versions](https://docs.microsoft.com/dotnet/framework/migration-guide/how-to-configure-an-app-to-support-net-framework-4-or-4-5).
-None of the other flags are needed.


### PR DESCRIPTION
- Removes v1-specific contents about *.exe.config*.
- Removes contents about manually configuring the service with the Service Control Manager and even the Registry Editor. Everything should have been fully configurable via the XML.