### PR TITLE
Remove content about renaming running executables

### DIFF
--- a/doc/deferredFileOperations.md
+++ b/doc/deferredFileOperations.md
@@ -19,9 +19,4 @@ example:
 c:\soft\sshd.exe.new>c:\bin\ssh.exe
 ```
 
-Note that it is apparently possible to [rename executables even when it's running](http://superuser.com/questions/488127/why-can-i-rename-a-running-executable-but-not-delete-it), which makes sense if you think about file handles.
-Kohsuke has failed to find any authoritative source of information about this, but experimentally this even works on Windows XP and presumably on all the later Windows versions. 
-This behavior can be used to update *WinSW.exe* itself.
-Also see `WINSW_EXECUTABLE` environment variable.
-
 The `<download>` element in the configuration file also provides an useful building block for a self updating service.


### PR DESCRIPTION
Dangerous, a bad practice, not part of Windows features.