### PR TITLE
Support proxy attribute for download

### DIFF
--- a/doc/xmlConfigFile.md
+++ b/doc/xmlConfigFile.md
@@ -186,7 +186,9 @@ For target servers using the HTTPS transfer protocol it is necessary, that the C
 By default, the `download` command does not fail the service startup if the operation fails (e.g. `from` is not available).
 In order to force the download failure in such case, it is possible to specify the `failOnError` boolean attribute.
 
-To specify a custom proxy you can put your proxy URL in the parameter `proxyServer`.
+To specify a custom proxy use the parameter `proxy` with the following formats:
+- With credentials: `http://USERNAME:PASSWORD@HOST:PORT/`.
+- Without credentials: `http://HOST:PORT/`.
 
 Examples:
 
@@ -195,14 +197,15 @@ Examples:
 
 <download from="http://example.com/some.dat" to="%BASE%\some.dat" failOnError="true"/>
 
-<download from="http://example.com/some.dat" to="%BASE%\some.dat" proxyServer="http://192.168.1.5:80/"/>
+<download from="http://example.com/some.dat" to="%BASE%\some.dat" proxy="http://192.168.1.5:80/"/>
 
 <download from="https://example.com/some.dat" to="%BASE%\some.dat" auth="sspi" />
 
 <download from="https://example.com/some.dat" to="%BASE%\some.dat" failOnError="true"
           auth="basic" user="aUser" password="aPassw0rd" />
 
-<download from="http://example.com/some.dat" to="%BASE%\some.dat" proxyServer="http://192.168.1.5:80/"
+<download from="http://example.com/some.dat" to="%BASE%\some.dat"
+	  proxy="http://aUser:aPassw0rd@192.168.1.5:80/"
           auth="basic" unsecureAuth="true"
           user="aUser" password="aPassw0rd" />
 ```

--- a/doc/xmlConfigFile.md
+++ b/doc/xmlConfigFile.md
@@ -186,6 +186,8 @@ For target servers using the HTTPS transfer protocol it is necessary, that the C
 By default, the `download` command does not fail the service startup if the operation fails (e.g. `from` is not available).
 In order to force the download failure in such case, it is possible to specify the `failOnError` boolean attribute.
 
+To specify a custom proxy you can put your proxy URL in the parameter `proxyServer`.
+
 Examples:
 
 ```xml
@@ -193,12 +195,14 @@ Examples:
 
 <download from="http://example.com/some.dat" to="%BASE%\some.dat" failOnError="true"/>
 
+<download from="http://example.com/some.dat" to="%BASE%\some.dat" proxyServer="http://192.168.1.5:80/"/>
+
 <download from="https://example.com/some.dat" to="%BASE%\some.dat" auth="sspi" />
 
 <download from="https://example.com/some.dat" to="%BASE%\some.dat" failOnError="true"
           auth="basic" user="aUser" password="aPassw0rd" />
 
-<download from="http://example.com/some.dat" to="%BASE%\some.dat"
+<download from="http://example.com/some.dat" to="%BASE%\some.dat" proxyServer="http://192.168.1.5:80/"
           auth="basic" unsecureAuth="true"
           user="aUser" password="aPassw0rd" />
 ```

--- a/src/Core/WinSWCore/Download.cs
+++ b/src/Core/WinSWCore/Download.cs
@@ -36,6 +36,7 @@ namespace winsw
         public readonly string? Password;
         public readonly bool UnsecureAuth;
         public readonly bool FailOnError;
+        public readonly string? ProxyServer;
 
         public string ShortId => $"(download from {From})";
 
@@ -75,11 +76,13 @@ namespace winsw
             AuthType auth = AuthType.none,
             string? username = null,
             string? password = null,
-            bool unsecureAuth = false)
+            bool unsecureAuth = false,
+            string? proxyServer = null)
         {
             From = from;
             To = to;
             FailOnError = failOnError;
+            ProxyServer = proxyServer;
             Auth = auth;
             Username = username;
             Password = password;
@@ -98,6 +101,7 @@ namespace winsw
 
             // All arguments below are optional
             FailOnError = XmlHelper.SingleAttribute(n, "failOnError", false);
+            ProxyServer = XmlHelper.SingleAttribute<string>(n, "proxyServer", null);
 
             Auth = XmlHelper.EnumAttribute(n, "auth", AuthType.none);
             Username = XmlHelper.SingleAttribute<string>(n, "user", null);
@@ -147,6 +151,10 @@ namespace winsw
 #endif
         {
             WebRequest request = WebRequest.Create(From);
+            if (!string.IsNullOrEmpty(ProxyServer))
+            {
+                request.Proxy = new WebProxy(ProxyServer);
+            }
 
             switch (Auth)
             {

--- a/src/Test/winswTests/DownloadTest.cs
+++ b/src/Test/winswTests/DownloadTest.cs
@@ -202,6 +202,35 @@ namespace winswTests
             Assert.That(() => GetSingleEntry(sd), Throws.TypeOf<InvalidDataException>().With.Message.StartsWith("Cannot parse <auth> Enum value from string 'digest'"));
         }
 
+        [TestCase("http://", "127.0.0.1:80", "egarcia", "Passw0rd")]
+        [TestCase("https://", "myurl.com.co:2298", "MyUsername", "P@ssw:rd")]
+        [TestCase("http://", "192.168.0.8:3030")]
+        public void Proxy_Credentials(string protocol, string address, string username = null, string password = null)
+        {
+            CustomProxyInformation cpi;
+            if (string.IsNullOrEmpty(username))
+            {
+                cpi = new CustomProxyInformation(protocol + address + "/");
+            }
+            else
+            {
+                cpi = new CustomProxyInformation(protocol + username + ":" + password + "@" + address + "/");
+            }
+
+            Assert.That(cpi.ServerAddress, Is.EqualTo(protocol + address + "/"));
+
+            if (string.IsNullOrEmpty(username))
+            {
+                Assert.IsNull(cpi.Credentials);
+            }
+            else
+            {
+                Assert.IsNotNull(cpi.Credentials);
+                Assert.That(cpi.Credentials.UserName, Is.EqualTo(username));
+                Assert.That(cpi.Credentials.Password, Is.EqualTo(password));
+            }
+        }
+
         private Download GetSingleEntry(ServiceDescriptor sd)
         {
             var downloads = sd.Downloads.ToArray();


### PR DESCRIPTION
This PR can be helpful for #490.  You will not need to copy the proxy settings to the system account (that can cause errors in other applications); just modify the XML configuration file (manually or programmatically) and restart the service.