### PR TITLE
Fix outdated tag

### DIFF
--- a/doc/extensions/runawayProcessKiller.md
+++ b/doc/extensions/runawayProcessKiller.md
@@ -21,7 +21,7 @@ The extension can be configured via the [XML configuration file](../xmlConfigFil
   <description>This is a stub service.</description>
   <executable>%BASE%\sleep.bat</executable>
   <arguments></arguments>
-  <logmode>rotate</logmode>
+  <log mode="roll"></log>
 
   <extensions>
 	<!-- This is a sample configuration for the RunawayProcessKiller extension. -->

--- a/doc/extensions/sharedDirectoryMapper.md
+++ b/doc/extensions/sharedDirectoryMapper.md
@@ -20,7 +20,7 @@ Configuration sample:
   <description>This is a stub service.</description>
   <executable>%BASE%\sleep.bat</executable>
   <arguments></arguments>
-  <logmode>rotate</logmode>
+  <log mode="roll"></log>
 
   <extensions>
     <extension enabled="true" className="winsw.Plugins.SharedDirectoryMapper.SharedDirectoryMapper" id="mapNetworDirs">

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -29,7 +29,7 @@ The example below is a primitive example being used in the Jenkins project:
   <env name="JENKINS_HOME" value="%BASE%"/>
   <executable>java</executable>
   <arguments>-Xrs -Xmx256m -jar "%BASE%\jenkins.war" --httpPort=8080</arguments>
-  <logmode>rotate</logmode>
+  <log mode="roll"></log>
 </service>
 ```
 

--- a/doc/loggingAndErrorReporting.md
+++ b/doc/loggingAndErrorReporting.md
@@ -34,7 +34,7 @@ Throw away stdout and stderr, and do not produce any log files at all.
 
 ## Roll mode
 
-Works like the append mode, but in addition, if the log file gets bigger than a set size, it gets rolles to *myapp.1.out.log*, *myapp.2.out.log* and so on. The nested `<sizeThreshold>` element specifies the rotation threshold in KB (defaults to 10MB), and the nested `<keepFiles>` element specifies the number of rolles files to keep (defaults to 8.)
+Works like the append mode, but in addition, if the log file gets bigger than a set size, it gets rolled to *myapp.1.out.log*, *myapp.2.out.log* and so on. The nested `<sizeThreshold>` element specifies the rotation threshold in KB (defaults to 10MB), and the nested `<keepFiles>` element specifies the number of rolled files to keep (defaults to 8.)
 
 ```xml
 <log mode="roll-by-size">
@@ -60,7 +60,7 @@ For example, in the above example, the log of Jan 1, 2013 gets written to `myapp
 
 ## Roll by size and time mode
 
-Works in a combination of roll size mode and roll time mode, if the log file gets bigger than a set size, it gets rolles using `<pattern>` provided.
+Works in a combination of roll size mode and roll time mode, if the log file gets bigger than a set size, it gets rolled using `<pattern>` provided.
 
 ```xml
 <log mode="roll-by-size-time">

--- a/doc/loggingAndErrorReporting.md
+++ b/doc/loggingAndErrorReporting.md
@@ -32,9 +32,9 @@ Throw away stdout and stderr, and do not produce any log files at all.
 <log mode="none"/>
 ```
 
-## Rotate mode
+## Roll mode
 
-Works like the append mode, but in addition, if the log file gets bigger than a set size, it gets rotated to *myapp.1.out.log*, *myapp.2.out.log* and so on. The nested `<sizeThreshold>` element specifies the rotation threshold in KB (defaults to 10MB), and the nested `<keepFiles>` element specifies the number of rotated files to keep (defaults to 8.)
+Works like the append mode, but in addition, if the log file gets bigger than a set size, it gets rolles to *myapp.1.out.log*, *myapp.2.out.log* and so on. The nested `<sizeThreshold>` element specifies the rotation threshold in KB (defaults to 10MB), and the nested `<keepFiles>` element specifies the number of rolles files to keep (defaults to 8.)
 
 ```xml
 <log mode="roll-by-size">
@@ -43,9 +43,9 @@ Works like the append mode, but in addition, if the log file gets bigger than a 
 </log>
 ```
 
-## Rotate by time mode
+## Roll by time mode
 
-Works like the rotate mode, except that instead of using the size as a threshold, use the time period as the threshold.
+Works like the roll mode, except that instead of using the size as a threshold, use the time period as the threshold.
 
 This configuration must accompany a nested `<pattern>` element, which specifies the timestamp pattern used as the log file name.
 
@@ -58,9 +58,9 @@ This configuration must accompany a nested `<pattern>` element, which specifies 
 The syntax of the pattern string is specified by [DateTime.ToString(String)](https://docs.microsoft.com/dotnet/api/system.datetime.tostring#System_DateTime_ToString_System_String_). 
 For example, in the above example, the log of Jan 1, 2013 gets written to `myapp.20130101.out.log` and `myapp.20130101.err.log`. 
 
-## Rotate by size and time mode
+## Roll by size and time mode
 
-Works in a combination of rotate size mode and rotate time mode, if the log file gets bigger than a set size, it gets rotated using `<pattern>` provided.
+Works in a combination of roll size mode and roll time mode, if the log file gets bigger than a set size, it gets rolles using `<pattern>` provided.
 
 ```xml
 <log mode="roll-by-size-time">

--- a/doc/xmlConfigFile.md
+++ b/doc/xmlConfigFile.md
@@ -19,7 +19,7 @@ Example:
   <env name="JENKINS_HOME" value="%BASE%"/>
   <executable>java</executable>
   <arguments>-Xrs -Xmx256m -jar "%BASE%\jenkins.war" --httpPort=8080</arguments>
-  <logmode>rotate</logmode>
+  <log mode="roll"></log>
 </service>
 ```
 

--- a/doc/xmlConfigFile.md
+++ b/doc/xmlConfigFile.md
@@ -88,7 +88,7 @@ Multiple elements can be used to specify multiple dependencies.
 
 ### logging
 
-Optionally set a different logging directory with `<logpath>` and startup `<logmode>`: reset (clear log), roll (move to \*.old) or append (default).
+Optionally set a different logging directory with `<logpath>` and startup `mode`: append (default), reset (clear log), ignore, roll (move to `\*.old`).
 
 See the [Logging and error reporting](loggingAndErrorReporting.md) page for more info.
 

--- a/examples/sample-allOptions.xml
+++ b/examples/sample-allOptions.xml
@@ -231,8 +231,8 @@ SECTION:Logging
       * append - Rust update the existing log
       * none - Do not save executable logs to the disk
       * reset - Wipe the log files on startup
-      * roll - Rotate logs based on size
-      * roll-by-time - Rotate logs based on time
+      * roll - Roll logs based on size
+      * roll-by-time - Roll logs based on time
       * rotate - Rotate logs based on size, (8 logs, 10MB each). This mode is deprecated, use "roll"
     Default mode: append
     

--- a/src/Core/WinSWCore/LogAppenders.cs
+++ b/src/Core/WinSWCore/LogAppenders.cs
@@ -222,7 +222,7 @@ namespace winsw
         // ReSharper disable once InconsistentNaming
         public static int BYTES_PER_MB = 1024 * BYTES_PER_KB;
         // ReSharper disable once InconsistentNaming
-        public static int DEFAULT_SIZE_THRESHOLD = 10 * BYTES_PER_MB; // rotate every 10MB.
+        public static int DEFAULT_SIZE_THRESHOLD = 10 * BYTES_PER_MB; // roll every 10MB.
         // ReSharper disable once InconsistentNaming
         public static int DEFAULT_FILES_TO_KEEP = 8;
 
@@ -283,11 +283,11 @@ namespace winsw
                     }
                     catch (IOException e)
                     {
-                        EventLogger.LogEvent("Failed to rotate log: " + e.Message);
+                        EventLogger.LogEvent("Failed to roll log: " + e.Message);
                     }
 
                     // even if the log rotation fails, create a new one, or else
-                    // we'll infinitely try to rotate.
+                    // we'll infinitely try to roll.
                     writer = CreateWriter(new FileStream(BaseLogFileName + ext, FileMode.Create));
                     fileLength = new FileInfo(BaseLogFileName + ext).Length;
                 }
@@ -302,7 +302,7 @@ namespace winsw
     }
 
     /// <summary>
-    /// Rotate log when a service is newly started.
+    /// Roll log when a service is newly started.
     /// </summary>
     public class RollingLogAppender : SimpleLogAppender
     {
@@ -426,7 +426,7 @@ namespace winsw
                     {
                         try
                         {
-                            // rotate file
+                            // roll file
                             var now = DateTime.Now;
                             var nextFileNumber = GetNextFileNumber(extension, baseDirectory, baseFileName, now);
                             var nextFileName =
@@ -435,7 +435,7 @@ namespace winsw
                             File.Move(logFile, nextFileName);
 
                             // even if the log rotation fails, create a new one, or else
-                            // we'll infinitely try to rotate.
+                            // we'll infinitely try to roll.
                             writer = CreateWriter(new FileStream(logFile, FileMode.Create));
                             fileLength = new FileInfo(logFile).Length;
                         }

--- a/src/Plugins/RunawayProcessKiller/sampleConfig.xml
+++ b/src/Plugins/RunawayProcessKiller/sampleConfig.xml
@@ -5,7 +5,7 @@
   <description>This service runs a slave for Jenkins continuous integration system.</description>
   <executable>C:\Program Files\Java\jre7\bin\java.exe</executable>
   <arguments>-Xrs -jar "%BASE%\slave.jar" -jnlpUrl ...</arguments>
-  <logmode>rotate</logmode>
+  <log mode="roll"></log>
 
   <extensions>
 	<!-- This is a sample configuration for the RunawayProcessKiller extension. -->

--- a/src/Plugins/SharedDirectoryMapper/sampleConfig.xml
+++ b/src/Plugins/SharedDirectoryMapper/sampleConfig.xml
@@ -5,7 +5,7 @@
   <description>This service runs a slave for Jenkins continuous integration system.</description>
   <executable>C:\Program Files\Java\jre7\bin\java.exe</executable>
   <arguments>-Xrs  -jar "%BASE%\slave.jar" -jnlpUrl ...</arguments>
-  <logmode>rotate</logmode>
+  <log mode="roll"></log>
 
   <extensions>
     <extension enabled="true" className="winsw.Plugins.SharedDirectoryMapper.SharedDirectoryMapper" id="mapNetworDirs">

--- a/src/Test/winswTests/Extensions/RunawayProcessKillerTest.cs
+++ b/src/Test/winswTests/Extensions/RunawayProcessKillerTest.cs
@@ -28,7 +28,7 @@ $@"<service>
   <description>This service runs a slave for Jenkins continuous integration system.</description>
   <executable>C:\Program Files\Java\jre7\bin\java.exe</executable>
   <arguments>-Xrs  -jar \""%BASE%\slave.jar\"" -jnlpUrl ...</arguments>
-  <log mode="roll"></log>
+  <log mode=""roll""></log>
   <extensions>
     <extension enabled=""true"" className=""{testExtension}"" id=""killRunawayProcess"">
       <pidfile>foo/bar/pid.txt</pidfile>

--- a/src/Test/winswTests/Extensions/RunawayProcessKillerTest.cs
+++ b/src/Test/winswTests/Extensions/RunawayProcessKillerTest.cs
@@ -28,7 +28,7 @@ $@"<service>
   <description>This service runs a slave for Jenkins continuous integration system.</description>
   <executable>C:\Program Files\Java\jre7\bin\java.exe</executable>
   <arguments>-Xrs  -jar \""%BASE%\slave.jar\"" -jnlpUrl ...</arguments>
-  <logmode>rotate</logmode>
+  <log mode="roll"></log>
   <extensions>
     <extension enabled=""true"" className=""{testExtension}"" id=""killRunawayProcess"">
       <pidfile>foo/bar/pid.txt</pidfile>

--- a/src/Test/winswTests/Extensions/SharedDirectoryMapperTest.cs
+++ b/src/Test/winswTests/Extensions/SharedDirectoryMapperTest.cs
@@ -22,7 +22,7 @@ $@"<service>
   <description>This service runs a slave for Jenkins continuous integration system.</description>
   <executable>C:\Program Files\Java\jre7\bin\java.exe</executable>
   <arguments>-Xrs  -jar \""%BASE%\slave.jar\"" -jnlpUrl ...</arguments>
-  <log mode="roll"></log>
+  <log mode=""roll""></log>
   <extensions>
     <extension enabled=""true"" className=""{testExtension}"" id=""mapNetworDirs"">
       <mapping>

--- a/src/Test/winswTests/Extensions/SharedDirectoryMapperTest.cs
+++ b/src/Test/winswTests/Extensions/SharedDirectoryMapperTest.cs
@@ -22,7 +22,7 @@ $@"<service>
   <description>This service runs a slave for Jenkins continuous integration system.</description>
   <executable>C:\Program Files\Java\jre7\bin\java.exe</executable>
   <arguments>-Xrs  -jar \""%BASE%\slave.jar\"" -jnlpUrl ...</arguments>
-  <logmode>rotate</logmode>
+  <log mode="roll"></log>
   <extensions>
     <extension enabled=""true"" className=""{testExtension}"" id=""mapNetworDirs"">
       <mapping>

--- a/src/Test/winswTests/ServiceDescriptorTests.cs
+++ b/src/Test/winswTests/ServiceDescriptorTests.cs
@@ -28,7 +28,7 @@ $@"<service>
   <description>The service.</description>
   <executable>node.exe</executable>
   <arguments>My Arguments</arguments>
-  <log mode="roll"></log>
+  <log mode=""roll""></log>
   <serviceaccount>
     <domain>{Domain}</domain>
     <user>{Username}</user>
@@ -58,7 +58,7 @@ $@"<service>
   <executable>node.exe</executable>
   <arguments>My Arguments</arguments>
   <startmode>roll</startmode>
-  <log mode="roll"></log>
+  <log mode=""roll""></log>
   <serviceaccount>
     <domain>{Domain}</domain>
     <user>{Username}</user>
@@ -84,7 +84,7 @@ $@"<service>
   <executable>node.exe</executable>
   <arguments>My Arguments</arguments>
   <startmode>manual</startmode>
-  <log mode="roll"></log>
+  <log mode=""roll""></log>
   <serviceaccount>
     <domain>{Domain}</domain>
     <user>{Username}</user>

--- a/src/Test/winswTests/ServiceDescriptorTests.cs
+++ b/src/Test/winswTests/ServiceDescriptorTests.cs
@@ -28,7 +28,7 @@ $@"<service>
   <description>The service.</description>
   <executable>node.exe</executable>
   <arguments>My Arguments</arguments>
-  <logmode>rotate</logmode>
+  <log mode="roll"></log>
   <serviceaccount>
     <domain>{Domain}</domain>
     <user>{Username}</user>
@@ -57,8 +57,8 @@ $@"<service>
   <description>The service.</description>
   <executable>node.exe</executable>
   <arguments>My Arguments</arguments>
-  <startmode>rotate</startmode>
-  <logmode>rotate</logmode>
+  <startmode>roll</startmode>
+  <log mode="roll"></log>
   <serviceaccount>
     <domain>{Domain}</domain>
     <user>{Username}</user>
@@ -84,7 +84,7 @@ $@"<service>
   <executable>node.exe</executable>
   <arguments>My Arguments</arguments>
   <startmode>manual</startmode>
-  <logmode>rotate</logmode>
+  <log mode="roll"></log>
   <serviceaccount>
     <domain>{Domain}</domain>
     <user>{Username}</user>

--- a/src/Test/winswTests/Util/CLITestHelper.cs
+++ b/src/Test/winswTests/Util/CLITestHelper.cs
@@ -20,7 +20,7 @@ $@"<service>
   <description>The service.</description>
   <executable>node.exe</executable>
   <arguments>My Arguments</arguments>
-  <log mode="roll"></log>
+  <log mode=""roll""></log>
   <workingdirectory>C:\winsw\workdir</workingdirectory>
   <logpath>C:\winsw\logs</logpath>
 </service>";

--- a/src/Test/winswTests/Util/CLITestHelper.cs
+++ b/src/Test/winswTests/Util/CLITestHelper.cs
@@ -20,7 +20,7 @@ $@"<service>
   <description>The service.</description>
   <executable>node.exe</executable>
   <arguments>My Arguments</arguments>
-  <logmode>rotate</logmode>
+  <log mode="roll"></log>
   <workingdirectory>C:\winsw\workdir</workingdirectory>
   <logpath>C:\winsw\logs</logpath>
 </service>";


### PR DESCRIPTION
According to `examples/sample-allOptions.xml`, `<logmode>` has been replaced by `<log></log>`; so does `rotate`.