### PR TITLE
Merge <domain> and <user> to support User Principal Name

### DIFF
--- a/src/Core/ServiceWrapper/Program.cs
+++ b/src/Core/ServiceWrapper/Program.cs
@@ -224,7 +224,7 @@ namespace winsw
                 {
                     if (descriptor.HasServiceAccount())
                     {
-                        username = descriptor.ServiceAccountUser;
+                        username = descriptor.ServiceAccountUserName;
                         password = descriptor.ServiceAccountPassword;
                         allowServiceLogonRight = descriptor.AllowServiceAcountLogonRight;
                     }
@@ -232,7 +232,7 @@ namespace winsw
 
                 if (allowServiceLogonRight)
                 {
-                    Security.AddServiceLogonRight(descriptor.ServiceAccountDomain!, descriptor.ServiceAccountName!);
+                    Security.AddServiceLogonRight(descriptor.ServiceAccountUserName!);
                 }
 
                 using Service sc = scm.CreateService(

--- a/src/Core/WinSWCore/Configuration/DefaultSettings.cs
+++ b/src/Core/WinSWCore/Configuration/DefaultSettings.cs
@@ -23,7 +23,7 @@ namespace winsw.Configuration
         // Installation
         public bool AllowServiceAcountLogonRight => false;
         public string? ServiceAccountPassword => null;
-        public string? ServiceAccountUser => null;
+        public string? ServiceAccountUserName => null;
         public Native.SC_ACTION[] FailureActions => new Native.SC_ACTION[0];
         public TimeSpan ResetFailureAfter => TimeSpan.FromDays(1);
 

--- a/src/Core/WinSWCore/Configuration/IWinSWConfiguration.cs
+++ b/src/Core/WinSWCore/Configuration/IWinSWConfiguration.cs
@@ -20,7 +20,7 @@ namespace winsw.Configuration
         // Installation
         bool AllowServiceAcountLogonRight { get; }
         string? ServiceAccountPassword { get; }
-        string? ServiceAccountUser { get; }
+        string? ServiceAccountUserName { get; }
         Native.SC_ACTION[] FailureActions { get; }
         TimeSpan ResetFailureAfter { get; }
 

--- a/src/Core/WinSWCore/Native/Security.cs
+++ b/src/Core/WinSWCore/Native/Security.cs
@@ -8,9 +8,9 @@ namespace winsw.Native
     internal static class Security
     {
         /// <exception cref="Win32Exception" />
-        internal static void AddServiceLogonRight(string domain, string user)
+        internal static void AddServiceLogonRight(string userName)
         {
-            IntPtr sid = GetAccountSid(domain, user);
+            IntPtr sid = GetAccountSid(userName);
 
             try
             {
@@ -24,17 +24,16 @@ namespace winsw.Native
         }
 
         /// <exception cref="Win32Exception" />
-        private static IntPtr GetAccountSid(string domain, string user)
+        private static IntPtr GetAccountSid(string accountName)
         {
             int sidSize = 0;
             int domainNameLength = 0;
 
-            if (domain == ".")
+            if (accountName.StartsWith(".\\"))
             {
-                domain = Environment.MachineName;
+                accountName = Environment.MachineName + accountName.Substring(1);
             }
 
-            string accountName = domain + "\\" + user;
             _ = LookupAccountName(null, accountName, IntPtr.Zero, ref sidSize, IntPtr.Zero, ref domainNameLength, out _);
 
             IntPtr sid = Marshal.AllocHGlobal(sidSize);

--- a/src/Core/WinSWCore/ServiceDescriptor.cs
+++ b/src/Core/WinSWCore/ServiceDescriptor.cs
@@ -645,17 +645,13 @@ namespace winsw
 
         protected string? AllowServiceLogon => GetServiceAccountPart("allowservicelogon");
 
-        protected internal string? ServiceAccountDomain => GetServiceAccountPart("domain");
-
-        protected internal string? ServiceAccountName => GetServiceAccountPart("user");
-
         public string? ServiceAccountPassword => GetServiceAccountPart("password");
 
-        public string? ServiceAccountUser => ServiceAccountName is null ? null : (ServiceAccountDomain ?? ".") + "\\" + ServiceAccountName;
+        public string? ServiceAccountUserName => GetServiceAccountPart("username");
 
         public bool HasServiceAccount()
         {
-            return !string.IsNullOrEmpty(ServiceAccountName);
+            return !string.IsNullOrEmpty(ServiceAccountUserName);
         }
 
         public bool AllowServiceAcountLogonRight

--- a/src/Test/winswTests/ServiceDescriptorTests.cs
+++ b/src/Test/winswTests/ServiceDescriptorTests.cs
@@ -30,8 +30,7 @@ $@"<service>
   <arguments>My Arguments</arguments>
   <log mode=""roll""></log>
   <serviceaccount>
-    <domain>{Domain}</domain>
-    <user>{Username}</user>
+    <username>{Domain}\{Username}</username>
     <password>{Password}</password>
     <allowservicelogon>{AllowServiceAccountLogonRight}</allowservicelogon>
   </serviceaccount>
@@ -60,8 +59,7 @@ $@"<service>
   <startmode>roll</startmode>
   <log mode=""roll""></log>
   <serviceaccount>
-    <domain>{Domain}</domain>
-    <user>{Username}</user>
+    <username>{Domain}\{Username}</username>
     <password>{Password}</password>
     <allowservicelogon>{AllowServiceAccountLogonRight}</allowservicelogon>
   </serviceaccount>
@@ -86,8 +84,7 @@ $@"<service>
   <startmode>manual</startmode>
   <log mode=""roll""></log>
   <serviceaccount>
-    <domain>{Domain}</domain>
-    <user>{Username}</user>
+    <username>{Domain}\{Username}</username>
     <password>{Password}</password>
     <allowservicelogon>{AllowServiceAccountLogonRight}</allowservicelogon>
   </serviceaccount>
@@ -116,7 +113,7 @@ $@"<service>
         public void VerifyUsername()
         {
             Debug.WriteLine("_extendedServiceDescriptor.WorkingDirectory :: " + _extendedServiceDescriptor.WorkingDirectory);
-            Assert.That(_extendedServiceDescriptor.ServiceAccountUser, Is.EqualTo(Domain + "\\" + Username));
+            Assert.That(_extendedServiceDescriptor.ServiceAccountUserName, Is.EqualTo(Domain + "\\" + Username));
         }
 
         [Test]


### PR DESCRIPTION
Fixes #508 

> NOTE
> This is not the final design.

## Breaking change

`<domain>` and `<user>` are removed. Use `<username>` instead.