### PR TITLE
Allow prompting for credentials

### DIFF
--- a/src/Core/WinSWCore/Native/CredentialApis.cs
+++ b/src/Core/WinSWCore/Native/CredentialApis.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace winsw.Native
+{
+    internal static class CredentialApis
+    {
+        internal const uint CREDUIWIN_GENERIC = 0x00000001;
+
+        [DllImport(Libraries.CredUI, SetLastError = true, CharSet = CharSet.Unicode, EntryPoint = "CredPackAuthenticationBufferW")]
+        internal static extern bool CredPackAuthenticationBuffer(
+            uint flags,
+            string userName,
+            string password,
+            IntPtr packedCredentials,
+            ref int packedCredentialsSize);
+
+        [DllImport(Libraries.CredUI, SetLastError = false, CharSet = CharSet.Unicode, EntryPoint = "CredUIPromptForWindowsCredentialsW")]
+        internal static extern int CredUIPromptForWindowsCredentials(
+            in CREDUI_INFO uiInfo,
+            uint authError,
+            ref uint authPackage,
+            IntPtr inAuthBuffer,
+            int inAuthBufferSize,
+            out IntPtr outAuthBuffer,
+            out uint outAuthBufferSize,
+            ref bool save,
+            uint flags);
+
+        [DllImport(Libraries.CredUI, SetLastError = true, CharSet = CharSet.Unicode, EntryPoint = "CredUnPackAuthenticationBufferW")]
+        internal static extern bool CredUnPackAuthenticationBuffer(
+            uint flags,
+            IntPtr authBuffer,
+            uint authBufferSize,
+            string? userName,
+            ref int maxUserName,
+            string? domainName,
+            IntPtr maxDomainName,
+            string? password,
+            ref int maxPassword);
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        internal struct CREDUI_INFO
+        {
+            internal int Size;
+            internal IntPtr ParentWindow;
+            internal string MessageText;
+            internal string CaptionText;
+            internal IntPtr BannerBitmap;
+        }
+    }
+}

--- a/src/Core/WinSWCore/Native/Errors.cs
+++ b/src/Core/WinSWCore/Native/Errors.cs
@@ -2,6 +2,7 @@
 {
     internal static class Errors
     {
+        internal const int ERROR_SUCCESS = 0;
         internal const int ERROR_ACCESS_DENIED = 5;
         internal const int ERROR_INVALID_HANDLE = 6;
         internal const int ERROR_INVALID_PARAMETER = 7;

--- a/src/Core/WinSWCore/Native/Libraries.cs
+++ b/src/Core/WinSWCore/Native/Libraries.cs
@@ -3,6 +3,7 @@
     internal static class Libraries
     {
         internal const string Advapi32 = "advapi32.dll";
+        internal const string CredUI = "credui.dll";
         internal const string Kernel32 = "kernel32.dll";
     }
 }

--- a/src/Core/WinSWCore/ServiceDescriptor.cs
+++ b/src/Core/WinSWCore/ServiceDescriptor.cs
@@ -643,6 +643,8 @@ namespace winsw
             return null;
         }
 
+        public string? ServiceAccountPrompt => GetServiceAccountPart("prompt")?.ToLowerInvariant();
+
         protected string? AllowServiceLogon => GetServiceAccountPart("allowservicelogon");
 
         public string? ServiceAccountPassword => GetServiceAccountPart("password");
@@ -651,7 +653,7 @@ namespace winsw
 
         public bool HasServiceAccount()
         {
-            return !string.IsNullOrEmpty(ServiceAccountUserName);
+            return this.dom.SelectSingleNode("//serviceaccount") != null;
         }
 
         public bool AllowServiceAcountLogonRight


### PR DESCRIPTION
Implements https://github.com/winsw/winsw/issues/308#issuecomment-613181403.

> NOTE
> This is not a final design.

Adds a `<prompt>` element under `<serviceaccount>` to allow prompting for user name and/or password when either is missing.

```xml
<prompt>dialog|console</prompt>
```

/cc @MrGrymReaper @m8urnett @laguiz @il--ya who may be interested in this area. Please add a reaction to indicate that you want to be subscribed to further updates.