### PR TITLE
Add a Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  # Enable version updates for npm
+  - package-ecosystem: "nuget"
+    directory: "/"
+    # Check the npm registry for updates every day (weekdays)
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,6 @@
 version: 2
 updates:
-  # Enable version updates for npm
   - package-ecosystem: "nuget"
     directory: "/"
-    # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: "daily"


### PR DESCRIPTION
Adds Dependabot for NuGet dependencies. Let's see whether it will pick up the current format