### PR TITLE
Introduce WinSW Lite

### DIFF
--- a/eng/build.yml
+++ b/eng/build.yml
@@ -41,9 +41,6 @@ jobs:
       arguments: -c $(BuildConfiguration) -p:Version=$(BuildVersion)
   - script: |
       dotnet publish src\WinSW\WinSW.csproj -c $(BuildConfiguration) -f net5.0 -r win-x64 -p:Version=$(BuildVersion)
-      dotnet publish src\WinSW\WinSW.csproj -c $(BuildConfiguration) -f net5.0 -r win-x86 -p:Version=$(BuildVersion)
-      dotnet publish src\WinSW\WinSW.csproj -c $(BuildConfiguration) -f net5.0 -r win-x64 -p:Version=$(BuildVersion) -p:IncludeNativeLibrariesInSingleFile=true
-      dotnet publish src\WinSW\WinSW.csproj -c $(BuildConfiguration) -f net5.0 -r win-x86 -p:Version=$(BuildVersion) -p:IncludeNativeLibrariesInSingleFile=true
     displayName: Build
   - task: DotNetCoreCLI@2
     displayName: Test
@@ -65,18 +62,9 @@ jobs:
   - publish: artifacts\publish\WinSW.NET461.exe
     artifact: WinSW.NET461.exe_$(BuildConfiguration)
     displayName: Publish .NET 4.6.1
-  - publish: artifacts\publish\WinSW.NETCore.x64.zip
-    artifact: WinSW.NETCore.x64.zip_$(BuildConfiguration)
-    displayName: Publish .NET Core x64 .zip
-  - publish: artifacts\publish\WinSW.NETCore.x86.zip
-    artifact: WinSW.NETCore.x86.zip_$(BuildConfiguration)
-    displayName: Publish .NET Core x86 .zip
   - publish: artifacts\publish\WinSW.NETCore.x64.exe
     artifact: WinSW.NETCore.x64.exe_$(BuildConfiguration)
     displayName: Publish .NET Core x64 .exe
-  - publish: artifacts\publish\WinSW.NETCore.x86.exe
-    artifact: WinSW.NETCore.x86.exe_$(BuildConfiguration)
-    displayName: Publish .NET Core x86 .exe
   - publish: $(Build.ArtifactStagingDirectory)\WinSW.$(BuildVersion).nupkg
     artifact: WinSW.nupkg_$(BuildConfiguration)
     displayName: Publish Nuget

--- a/src/NuGet.Config
+++ b/src/NuGet.Config
@@ -2,6 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
+    <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/WinSW/WinSW.csproj
+++ b/src/WinSW/WinSW.csproj
@@ -28,6 +28,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+    <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="1.0.0-alpha-*" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.7.0" />
   </ItemGroup>
 
@@ -57,7 +58,7 @@
   <Target Name="PublishCoreExe" AfterTargets="Publish" Condition="'$(TargetFramework)' == 'net5.0' and '$(IncludeNativeLibrariesInSingleFile)' == 'true'">
 
     <MakeDir Directories="$(ArtifactsPublishDir)" />
-    <Copy SourceFiles="$(PublishDir)$(TargetName).exe" DestinationFiles="$(ArtifactsPublishDir)WinSW.NETCore.$(PlatformTarget).exe" />
+    <Copy SourceFiles="$(OutputPath)native\$(TargetName).exe" DestinationFiles="$(ArtifactsPublishDir)WinSW.NETCore.$(PlatformTarget).exe" />
 
   </Target>
 


### PR DESCRIPTION
### Pros

- Smaller size.
- Faster startup.
- No framework/runtime dependency.

### Cons

- No internal plugin support at the moment.
- No external plugin support without rebuild.
- No x86 support in short term.
- May not be compatible with third-party libraries.

### Code size

14.7 MB