### PR TITLE
Update codebase to use IWinSWConfiguration instead of ServiceDescriptor internally

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/src/Core/ServiceWrapper/Program.cs
+++ b/src/Core/ServiceWrapper/Program.cs
@@ -18,6 +18,7 @@ using log4net.Appender;
 using log4net.Config;
 using log4net.Core;
 using log4net.Layout;
+using winsw.Configuration;
 using winsw.Logging;
 using winsw.Native;
 using winsw.Util;
@@ -533,7 +534,7 @@ namespace winsw
         [DoesNotReturn]
         private static void ThrowNoSuchService() => throw new WmiException(ReturnValue.NoSuchService);
 
-        private static void InitLoggers(ServiceDescriptor descriptor, bool enableConsoleLogging)
+        private static void InitLoggers(IWinSWConfiguration descriptor, bool enableConsoleLogging)
         {
             // TODO: Make logging levels configurable
             Level fileLogLevel = Level.Debug;

--- a/src/Core/ServiceWrapper/WrapperService.cs
+++ b/src/Core/ServiceWrapper/WrapperService.cs
@@ -10,6 +10,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 #endif
 using log4net;
+using winsw.Configuration;
 using winsw.Extensions;
 using winsw.Logging;
 using winsw.Native;
@@ -22,7 +23,7 @@ namespace winsw
         private ServiceApis.SERVICE_STATUS _wrapperServiceStatus;
 
         private readonly Process _process = new Process();
-        private readonly ServiceDescriptor _descriptor;
+        private readonly IWinSWConfiguration _descriptor;
         private Dictionary<string, string>? _envs;
 
         internal WinSWExtensionManager ExtensionManager { get; private set; }
@@ -54,7 +55,7 @@ namespace winsw
         /// </summary>
         public bool IsShuttingDown => _systemShuttingdown;
 
-        public WrapperService(ServiceDescriptor descriptor)
+        public WrapperService(IWinSWConfiguration descriptor)
         {
             _descriptor = descriptor;
             ServiceName = _descriptor.Id;

--- a/src/Core/ServiceWrapper/winsw.csproj
+++ b/src/Core/ServiceWrapper/winsw.csproj
@@ -16,6 +16,10 @@
     <AssemblyName>WindowsService</AssemblyName>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+    <ILMergeVersion>3.0.41</ILMergeVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="log4net" Version="2.0.8" />
   </ItemGroup>
@@ -26,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
-    <PackageReference Include="ilmerge" Version="3.0.29" />
+    <PackageReference Include="ilmerge" Version="$(ILMergeVersion)" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
     <Reference Include="System.ServiceProcess" />
   </ItemGroup>
@@ -96,7 +100,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-      <ILMerge>$(NuGetPackageRoot)ilmerge\3.0.29\tools\net452\ILMerge.exe</ILMerge>
+      <ILMerge>$(NuGetPackageRoot)ilmerge\$(ILMergeVersion)\tools\net452\ILMerge.exe</ILMerge>
       <ILMergeArgs>/targetplatform:$(TargetPlatform) /out:$(OutputAssembly) $(InputAssemblies)</ILMergeArgs>
       <ILMergeCommand>"$(ILMerge)" $(ILMergeArgs)</ILMergeCommand>
     </PropertyGroup>

--- a/src/Core/WinSWCore/Configuration/DefaultSettings.cs
+++ b/src/Core/WinSWCore/Configuration/DefaultSettings.cs
@@ -63,5 +63,13 @@ namespace winsw.Configuration
 
         // Extensions
         public XmlNode? ExtensionsConfiguration => null;
+
+        public string BaseName => throw new NotImplementedException();
+
+        public string BasePath => throw new NotImplementedException();
+
+        public string[] ExtensionIds => throw new NotImplementedException();
+
+        public LogHandler LogHandler => throw new NotImplementedException();
     }
 }

--- a/src/Core/WinSWCore/Configuration/IWinSWConfiguration.cs
+++ b/src/Core/WinSWCore/Configuration/IWinSWConfiguration.cs
@@ -55,5 +55,13 @@ namespace winsw.Configuration
 
         // Extensions
         XmlNode? ExtensionsConfiguration { get; }
+
+        string BaseName { get; }
+
+        string BasePath { get;  }
+
+        string[] ExtensionIds { get; }
+
+        LogHandler LogHandler { get; }
     }
 }

--- a/src/Core/WinSWCore/Extensions/AbstractWinSWExtension.cs
+++ b/src/Core/WinSWCore/Extensions/AbstractWinSWExtension.cs
@@ -1,4 +1,5 @@
 ﻿using System.Xml;
+using winsw.Configuration;
 
 namespace winsw.Extensions
 {
@@ -10,7 +11,7 @@ namespace winsw.Extensions
         public WinSWExtensionDescriptor Descriptor { get; set; }
 #pragma warning restore CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
 
-        public virtual void Configure(ServiceDescriptor descriptor, XmlNode node)
+        public virtual void Configure(IWinSWConfiguration descriptor, XmlNode node)
         {
             // Do nothing
         }

--- a/src/Core/WinSWCore/Extensions/IWinSWExtension.cs
+++ b/src/Core/WinSWCore/Extensions/IWinSWExtension.cs
@@ -1,4 +1,5 @@
 ﻿using System.Xml;
+using winsw.Configuration;
 
 namespace winsw.Extensions
 {
@@ -27,7 +28,7 @@ namespace winsw.Extensions
         /// </summary>
         /// <param name="descriptor">Service descriptor</param>
         /// <param name="node">Configuration node</param>
-        void Configure(ServiceDescriptor descriptor, XmlNode node);
+        void Configure(IWinSWConfiguration descriptor, XmlNode node);
 
         /// <summary>
         /// Start handler. Called during startup of the service before the child process.

--- a/src/Core/WinSWCore/Extensions/WinSWExtensionManager.cs
+++ b/src/Core/WinSWCore/Extensions/WinSWExtensionManager.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Xml;
 using log4net;
+using winsw.Configuration;
 
 namespace winsw.Extensions
 {
@@ -9,11 +10,11 @@ namespace winsw.Extensions
     {
         public Dictionary<string, IWinSWExtension> Extensions { get; private set; }
 
-        public ServiceDescriptor ServiceDescriptor { get; private set; }
+        public IWinSWConfiguration ServiceDescriptor { get; private set; }
 
         private static readonly ILog Log = LogManager.GetLogger(typeof(WinSWExtensionManager));
 
-        public WinSWExtensionManager(ServiceDescriptor serviceDescriptor)
+        public WinSWExtensionManager(IWinSWConfiguration serviceDescriptor)
         {
             ServiceDescriptor = serviceDescriptor;
             Extensions = new Dictionary<string, IWinSWExtension>();

--- a/src/Core/WinSWCore/ServiceDescriptor.cs
+++ b/src/Core/WinSWCore/ServiceDescriptor.cs
@@ -726,5 +726,9 @@ namespace winsw
 
             return environment;
         }
+
+        //TODO : Implement
+        string[] IWinSWConfiguration.ExtensionIds => throw new NotImplementedException();
+
     }
 }

--- a/src/Plugins/RunawayProcessKiller/RunawayProcessKillerExtension.cs
+++ b/src/Plugins/RunawayProcessKiller/RunawayProcessKillerExtension.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Text;
 using System.Xml;
 using log4net;
+using winsw.Configuration;
 using winsw.Extensions;
 using winsw.Util;
 using static winsw.Plugins.RunawayProcessKiller.RunawayProcessKillerExtension.NativeMethods;
@@ -179,7 +180,7 @@ namespace winsw.Plugins.RunawayProcessKiller
             return parameters.Environment;
         }
 
-        public override void Configure(ServiceDescriptor descriptor, XmlNode node)
+        public override void Configure(IWinSWConfiguration descriptor, XmlNode node)
         {
             // We expect the upper logic to process any errors
             // TODO: a better parser API for types would be useful

--- a/src/Plugins/SharedDirectoryMapper/SharedDirectoryMapper.cs
+++ b/src/Plugins/SharedDirectoryMapper/SharedDirectoryMapper.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Xml;
 using log4net;
+using winsw.Configuration;
 using winsw.Extensions;
 using winsw.Util;
 
@@ -25,7 +26,7 @@ namespace winsw.Plugins.SharedDirectoryMapper
             _entries.Add(config);
         }
 
-        public override void Configure(ServiceDescriptor descriptor, XmlNode node)
+        public override void Configure(IWinSWConfiguration descriptor, XmlNode node)
         {
             XmlNodeList? mapNodes = XmlHelper.SingleNode(node, "mapping", false)!.SelectNodes("map");
             if (mapNodes != null)

--- a/src/Test/winswTests/winswTests.csproj
+++ b/src/Test/winswTests/winswTests.csproj
@@ -8,14 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.2.0">
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="log4net" Version="2.0.8" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">


### PR DESCRIPTION
Related Issue : https://github.com/winsw/winsw/issues/544

In current implementation of WinSW it is not possible to use any other configuration type since Program is strictly requiring `ServiceDescriptor` type.  So when YAML Configuration implemented it is not possible to use both XML and YAML configuration at the same time. So in this PR Update Program to requiring `IWinSWConfiguration` type which is the base type of both XML and YAML configurations.

Work Done Yet

- [x] - IWinSWConfiguration Support
- [ ] - Update Unit Test