### PR TITLE
Set a default working directory for the wrapper

### DIFF
--- a/src/WinSW.Core/Configuration/DefaultSettings.cs
+++ b/src/WinSW.Core/Configuration/DefaultSettings.cs
@@ -12,6 +12,8 @@ namespace WinSW.Configuration
     /// </summary>
     public sealed class DefaultWinSWSettings : IWinSWConfiguration
     {
+        public string FullPath => throw new InvalidOperationException(nameof(this.FullPath) + " must be specified.");
+
         public string Id => throw new InvalidOperationException(nameof(this.Id) + " must be specified.");
 
         public string Caption => string.Empty;
@@ -44,7 +46,7 @@ namespace WinSW.Configuration
 
         public string? StopArguments => null;
 
-        public string WorkingDirectory => Path.GetDirectoryName(this.ExecutablePath)!;
+        public string WorkingDirectory => Path.GetDirectoryName(this.FullPath)!;
 
         public ProcessPriorityClass Priority => ProcessPriorityClass.Normal;
 

--- a/src/WinSW.Core/Configuration/IWinSWConfiguration.cs
+++ b/src/WinSW.Core/Configuration/IWinSWConfiguration.cs
@@ -9,6 +9,8 @@ namespace WinSW.Configuration
     // TODO: Document the parameters && refactor
     public interface IWinSWConfiguration
     {
+        string FullPath { get; }
+
         string Id { get; }
 
         string Caption { get; }

--- a/src/WinSW.Core/ServiceDescriptor.cs
+++ b/src/WinSW.Core/ServiceDescriptor.cs
@@ -25,6 +25,8 @@ namespace WinSW
 
         public static DefaultWinSWSettings Defaults { get; } = new DefaultWinSWSettings();
 
+        public string FullPath { get; }
+
         /// <summary>
         /// Where did we find the configuration file?
         ///
@@ -48,7 +50,8 @@ namespace WinSW
             string baseName = Path.GetFileNameWithoutExtension(path);
             string baseDir = Path.GetDirectoryName(path)!;
 
-            if (!File.Exists(Path.Combine(baseDir, baseName + ".xml")))
+            string fullPath = this.FullPath = Path.Combine(baseDir, baseName + ".xml");
+            if (!File.Exists(fullPath))
             {
                 throw new FileNotFoundException("Unable to locate " + baseName + ".xml file within executable directory");
             }
@@ -58,7 +61,7 @@ namespace WinSW
 
             try
             {
-                this.dom.Load(this.BasePath + ".xml");
+                this.dom.Load(fullPath);
             }
             catch (XmlException e)
             {
@@ -88,10 +91,10 @@ namespace WinSW
                 throw new FileNotFoundException(null, path);
             }
 
-            string baseName = Path.GetFileNameWithoutExtension(path);
-            string baseDir = Path.GetDirectoryName(Path.GetFullPath(path))!;
+            string fullPath = this.FullPath = Path.GetFullPath(path);
+            string baseName = this.BaseName = Path.GetFileNameWithoutExtension(path);
+            string baseDir = Path.GetDirectoryName(fullPath)!;
 
-            this.BaseName = baseName;
             this.BasePath = Path.Combine(baseDir, baseName);
 
             try

--- a/src/WinSW.Tests/Util/ServiceDescriptorAssert.cs
+++ b/src/WinSW.Tests/Util/ServiceDescriptorAssert.cs
@@ -53,8 +53,10 @@ namespace WinSW.Tests.Util
             get
             {
                 var properties = AllProperties;
+                properties.Remove("FullPath");
                 properties.Remove("Id");
                 properties.Remove("Executable");
+                properties.Remove("WorkingDirectory");
                 return properties;
             }
         }

--- a/src/WinSW/WrapperService.cs
+++ b/src/WinSW/WrapperService.cs
@@ -63,6 +63,8 @@ namespace WinSW
             {
                 this.AcceptPreshutdown();
             }
+
+            Environment.CurrentDirectory = descriptor.WorkingDirectory;
         }
 
         /// <summary>


### PR DESCRIPTION
*C:\Windows\System32\\* doesn't make much sense for most Windows apps. The default working directory of child processes is set to the executable directory since WinSW 1.12. This sets it for the wrapper as well, which allows the use of relative paths.