### PR TITLE
Fix service crashes

### DIFF
--- a/src/WinSW.Tests/CommandLineTests.cs
+++ b/src/WinSW.Tests/CommandLineTests.cs
@@ -38,6 +38,10 @@ namespace WinSW.Tests
                         Assert.Equal(ServiceControllerStatus.Running, controller.Status);
                         Assert.True(controller.CanStop);
 
+                        Assert.EndsWith(
+                            ServiceMessages.StartedSuccessfully + Environment.NewLine,
+                            File.ReadAllText(Path.ChangeExtension(config.FullPath, ".wrapper.log")));
+
                         if (Environment.GetEnvironmentVariable("System.DefinitionId") != null)
                         {
                             session = new InterProcessCodeCoverageSession(Helper.Name);
@@ -48,6 +52,10 @@ namespace WinSW.Tests
                         _ = Helper.Test(new[] { "stop", config.FullPath }, config);
                         controller.Refresh();
                         Assert.Equal(ServiceControllerStatus.Stopped, controller.Status);
+
+                        Assert.EndsWith(
+                            ServiceMessages.StoppedSuccessfully + Environment.NewLine,
+                            File.ReadAllText(Path.ChangeExtension(config.FullPath, ".wrapper.log")));
                     }
                 }
                 finally

--- a/src/WinSW/ServiceMessages.cs
+++ b/src/WinSW/ServiceMessages.cs
@@ -1,0 +1,8 @@
+﻿namespace WinSW
+{
+    internal static class ServiceMessages
+    {
+        internal const string StartedSuccessfully = "Service started successfully.";
+        internal const string StoppedSuccessfully = "Service stopped successfully.";
+    }
+}

--- a/src/WinSW/WrapperService.cs
+++ b/src/WinSW/WrapperService.cs
@@ -11,6 +11,7 @@ using WinSW.Extensions;
 using WinSW.Logging;
 using WinSW.Native;
 using WinSW.Util;
+using Messages = WinSW.ServiceMessages;
 
 namespace WinSW
 {
@@ -206,7 +207,7 @@ namespace WinSW
             try
             {
                 this.DoStart();
-                this.LogMinimal("Service started successfully.");
+                this.LogMinimal(Messages.StartedSuccessfully);
             }
             catch (Exception e)
             {
@@ -220,7 +221,7 @@ namespace WinSW
             try
             {
                 this.DoStop();
-                this.LogMinimal("Service stopped successfully.");
+                this.LogMinimal(Messages.StoppedSuccessfully);
             }
             catch (Exception e)
             {
@@ -256,6 +257,8 @@ namespace WinSW
         private void DoStart()
         {
             bool succeeded = ConsoleApis.FreeConsole();
+            Debug.Assert(succeeded);
+            succeeded = ConsoleApis.SetConsoleCtrlHandler(null, true);
             Debug.Assert(succeeded);
 
             this.HandleFileCopies();
@@ -561,7 +564,9 @@ namespace WinSW
                 }
             }
 
-            bool succeeded = ConsoleApis.AllocConsole();
+            bool succeeded = ConsoleApis.AllocConsole(); // inherited
+            Debug.Assert(succeeded);
+            succeeded = ConsoleApis.SetConsoleCtrlHandler(null, false); // inherited
             Debug.Assert(succeeded);
 
             Process process;
@@ -572,6 +577,8 @@ namespace WinSW
             finally
             {
                 succeeded = ConsoleApis.FreeConsole();
+                Debug.Assert(succeeded);
+                succeeded = ConsoleApis.SetConsoleCtrlHandler(null, true);
                 Debug.Assert(succeeded);
             }
 


### PR DESCRIPTION
### Codes

```cs
Log.Debug("Sending Ctrl+C...");

if (!SetConsoleCtrlHandler(null, true))
    throw new Win32Exception();

if (!GenerateConsoleCtrlEvent(CtrlEvents.CTRL_C_EVENT, 0))
    throw new Win32Exception();

if (!SetConsoleCtrlHandler(null, false))
    throw new Win32Exception();

bool succeeded = FreeConsole();
Debug.Assert(succeeded);

Log.Debug("Sent Ctrl+C.");
```

### Test codes

```cs
Assert.EndsWith(
    ServiceMessages.StoppedSuccessfully + Environment.NewLine,
    File.ReadAllText(Path.ChangeExtension(config.FullPath, ".wrapper.log")));
```

### Test output

```
  Error Message:
   Assert.EndsWith() Failure:
Expected:    Service stopped successfully.

Actual:   ···430 DEBUG - Sending Ctrl+C...
```