### PR TITLE
Auto refresh

### DIFF
--- a/src/WinSW.Core/Configuration/XmlServiceConfig.cs
+++ b/src/WinSW.Core/Configuration/XmlServiceConfig.cs
@@ -677,6 +677,8 @@ namespace WinSW
 
         public string? SecurityDescriptor => this.SingleElement("securityDescriptor", true);
 
+        public bool AutoRefresh => this.SingleBoolElement("autoRefresh", true);
+
         private Dictionary<string, string> LoadEnvironmentVariables()
         {
             XmlNodeList nodeList = this.dom.SelectNodes("//env");

--- a/src/WinSW.Core/Native/RegistryApis.cs
+++ b/src/WinSW.Core/Native/RegistryApis.cs
@@ -1,0 +1,31 @@
+﻿using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace WinSW.Native
+{
+    internal static class RegistryApis
+    {
+        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode)]
+        internal static extern unsafe int RegQueryInfoKeyW(
+            SafeRegistryHandle keyHandle,
+            char* @class,
+            int* classLength,
+            int* reserved,
+            int* subKeysCount,
+            int* maxSubKeyLength,
+            int* maxClassLength,
+            int* valuesCount,
+            int* maxValueNameLength,
+            int* maxValueLength,
+            int* securityDescriptorLength,
+            out FILETIME lastWriteTime);
+
+        internal struct FILETIME
+        {
+            internal int LowDateTime;
+            internal int HighDateTime;
+
+            public long ToTicks() => ((long)this.HighDateTime << 32) + this.LowDateTime;
+        }
+    }
+}

--- a/src/WinSW.Core/Util/RegistryKeyExtensions.cs
+++ b/src/WinSW.Core/Util/RegistryKeyExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Microsoft.Win32;
+using WinSW.Native;
+using static WinSW.Native.RegistryApis;
+
+namespace WinSW.Util
+{
+    internal static class RegistryKeyExtensions
+    {
+        /// <exception cref="CommandException" />
+        internal static unsafe DateTime GetLastWriteTime(this RegistryKey registryKey)
+        {
+            int error = RegQueryInfoKeyW(registryKey.Handle, null, null, null, null, null, null, null, null, null, null, out FILETIME lastWriteTime);
+            if (error != Errors.ERROR_SUCCESS)
+            {
+                Throw.Command.Win32Exception(error, "Failed to query registry key.");
+            }
+
+            return DateTime.FromFileTime(lastWriteTime.ToTicks());
+        }
+    }
+}

--- a/src/WinSW.Core/WinSW.Core.csproj
+++ b/src/WinSW.Core/WinSW.Core.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+    <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
     <PackageReference Include="System.Diagnostics.EventLog" Version="4.7.0" />
     <PackageReference Include="System.Security.AccessControl" Version="4.7.0" />
   </ItemGroup>


### PR DESCRIPTION
Fixes #256 
Contributes to #297 
Contributes to #606 

Automatically refreshes service properties if the config file is newer when the service is started or a command with write access is executed.

Enabled by default. Specify `<autoRefresh>false</autoRefresh>` to override.

### Known issues

The last write time of the registry key sometimes isn't updated (or is updated abnormally like the followings)... so you may end up with refreshing the service indefinitely.

```console
> WinSW.NET461.exe stop
file     last modified at 2020-08-15 3:39:23
registry last modified at 2020-08-15 3:25:44
03:39:27,053 - Service 'ABCD (ABC)' was refreshed successfully.
03:39:27,073 - Stopping service 'ABCD (ABC)'...
03:39:27,077 - Service 'ABCD (ABC)' has already stopped.

> WinSW.NET461.exe stop
file     last modified at 2020-08-15 3:39:30
registry last modified at 2020-08-15 3:32:17
03:39:33,356 - Service 'ABCDE (ABC)' was refreshed successfully.
03:39:33,376 - Stopping service 'ABCDE (ABC)'...
03:39:33,381 - Service 'ABCDE (ABC)' has already stopped.

> WinSW.NET461.exe stop
file     last modified at 2020-08-15 3:39:30
registry last modified at 2020-08-15 3:32:23
03:40:35,601 - Service 'ABCDE (ABC)' was refreshed successfully.
03:40:35,621 - Stopping service 'ABCDE (ABC)'...
03:40:35,625 - Service 'ABCDE (ABC)' has already stopped.
```

/cc @ricardopolo @losvedir