### PR TITLE
Fix installation crashes when `allowservicelogon` is `true`

### DIFF
--- a/src/Core/WinSWCore/Native/Security.cs
+++ b/src/Core/WinSWCore/Native/Security.cs
@@ -17,7 +17,6 @@ namespace WinSW.Native
             }
             finally
             {
-                _ = FreeSid(sid);
                 Marshal.FreeHGlobal(sid);
             }
         }

--- a/src/Core/WinSWCore/Native/SecurityApis.cs
+++ b/src/Core/WinSWCore/Native/SecurityApis.cs
@@ -7,9 +7,6 @@ namespace WinSW.Native
 {
     internal static class SecurityApis
     {
-        [DllImport(Libraries.Advapi32, SetLastError = false)]
-        internal static extern IntPtr FreeSid(IntPtr sid);
-
         [DllImport(Libraries.Advapi32, SetLastError = true)]
         internal static extern bool GetTokenInformation(
             IntPtr tokenHandle,


### PR DESCRIPTION
Fixes #659 