### PR TITLE
Enable member-level trimming

### DIFF
--- a/src/WinSW/WinSW.csproj
+++ b/src/WinSW/WinSW.csproj
@@ -7,6 +7,7 @@
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PublishTrimmed>true</PublishTrimmed>
+    <TrimMode>Link</TrimMode>
 
     <AssemblyTitle>Windows Service Wrapper</AssemblyTitle>
     <Description>Allows arbitrary process to run as a Windows service by wrapping it.</Description>


### PR DESCRIPTION
Continued from #651

*WinSW.NETCore.x64.exe:* 27.2 MB -> 15.6 MB

*WinSW.NETCore.x64.zip:* 11.8 MB -> 6.92 MB