### PR TITLE
Ensure we close correct handle after checking if service exists

### DIFF
--- a/src/WinSW.Core/Native/Service.cs
+++ b/src/WinSW.Core/Native/Service.cs
@@ -164,13 +164,13 @@ namespace WinSW.Native
 
         internal bool ServiceExists(string serviceName)
         {
-            var serviceHandle = ServiceApis.OpenService(this.handle, serviceName, ServiceAccess.All);
+            var serviceHandle = ServiceApis.OpenService(this.handle, serviceName, ServiceAccess.QueryStatus);
             if (serviceHandle == IntPtr.Zero)
             {
                 return false;
             }
 
-            _ = CloseServiceHandle(this.handle);
+            _ = CloseServiceHandle(serviceHandle);
             return true;
         }
 


### PR DESCRIPTION
Previously, this code would close the Service Control Manager (SCM)
handle instead of the service handle, meaning:

- any future calls to the SCM would fail due to invalid handle
- a handle to the service was left open in error

Also, reduce the access rights given to the handle, as we don't need
ALL rights just to check if the service exists.