### PR TITLE
Fix typo in the configuration sample

### DIFF
--- a/samples/complete.xml
+++ b/samples/complete.xml
@@ -216,7 +216,7 @@ SECTION:Logging
     OPTION: log
     Defines logging mode for logs produced by the executable.
     Supported modes:
-      * append - Rust update the existing log
+      * append - Just update the existing log
       * none - Do not save executable logs to the disk
       * reset - Wipe the log files on startup
       * roll - Roll logs based on size


### PR DESCRIPTION
Since I don't know what Rust would mean here, I assume that what's meant was Just. :)