### PR TITLE
V2 Fix Race Condition in ProcessHelper.StartProcessAndCallbackForExit()

### DIFF
--- a/src/WinSW.Core/Util/ProcessHelper.cs
+++ b/src/WinSW.Core/Util/ProcessHelper.cs
@@ -249,7 +249,6 @@ namespace WinSW.Util
             // Redirect logs if required
             if (logHandler != null)
             {
-                Logger.Debug("Forwarding logs of the process " + processToStart + " to " + logHandler);
                 logHandler.Log(
                     ps.RedirectStandardOutput ? processToStart.StandardOutput : StreamReader.Null,
                     ps.RedirectStandardError ? processToStart.StandardError : StreamReader.Null);


### PR DESCRIPTION
If the process to start exits too early then the implicit Process.toString() in [ProcessHelper.StartProcessAndCallbackForExit()](https://github.com/winsw/winsw/blob/v2.11.0/src/WinSW.Core/Util/ProcessHelper.cs#L252)
````
Logger.Debug("Forwarding logs of the process " + processToStart + " to " + logHandler);
````
will fail with the following Exception
````
System.InvalidOperationException: Process has exited, so the requested information is not available.
       at System.Diagnostics.Process.EnsureState(State state)
       at System.Diagnostics.Process.get_ProcessName()
       at System.Diagnostics.Process.ToString()
       at WinSW.Util.ProcessHelper.StartProcessAndCallbackForExit(Process processToStart, String executable, String arguments, Dictionary`2 envVars, String workingDirectory, Nullable`1 priority, ProcessCompletionCallback callback, LogHandler logHandler, Boolean hideWindow)
       at WinSW.WrapperService.StartProcess(Process processToStart, String arguments, String executable, LogHandler logHandler)
       at WinSW.WrapperService.DoStart()
       at WinSW.WrapperService.OnStart(String[] args)
````

This Exception is then caught in [WrapperService.OnStart()](https://github.com/winsw/winsw/blob/v2.11.0/src/WinSW/WrapperService.cs#L180) which throws uncaught. This prevents the Service from start and possible recovery options (restart on failure) will not be triggered - the Service will not try to restart.